### PR TITLE
Introduce hidden flags to check subcommand

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -50,21 +50,12 @@ failure and exit with a non-zero exit code.`,
 	var proxy bool
 	var namespace string
 	var impersonateGroup []string
-	var cniNamespace string
-	var cniEnabled bool
-	var preInstallOnly bool
 	cmd.Flags().BoolVar(&proxy, "proxy", false, "")
 	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "")
 	cmd.Flags().StringArrayVar(&impersonateGroup, "as-group", []string{}, "")
-	cmd.Flags().StringVarP(&cniNamespace, "cni-namespace", "", "", "")
-	cmd.Flags().BoolVar(&cniEnabled, "linkerd-cni-enabled", false, "")
-	cmd.Flags().BoolVar(&preInstallOnly, "pre", false, "")
 	cmd.Flags().MarkHidden("proxy")
 	cmd.Flags().MarkHidden("namespace")
 	cmd.Flags().MarkHidden("as-group")
-	cmd.Flags().MarkHidden("cni-namespace")
-	cmd.Flags().MarkHidden("linkerd-cni-enabled")
-	cmd.Flags().MarkHidden("pre")
 
 	return cmd
 }


### PR DESCRIPTION
Linkerd extensions must support a common set of subcommands and flags.

Introduce some additional check subcommand flags, but mark them hidden,
as they are unused by this extension.

Relates to linkerd/linkerd2#5692 and linkerd/linkerd2#5762

Signed-off-by: Andrew Seigner <siggy@buoyant.io>