### PR TITLE
Add linux-arm support to release

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -54,6 +54,10 @@ jobs:
           goos: linux
           goarch: arm64
           exe: ""
+        - platform: linux-arm
+          goos: linux
+          goarch: arm
+          exe: ""
         - platform: darwin
           goos: darwin
           goarch: ""
@@ -153,6 +157,8 @@ jobs:
         - platform: linux-amd64
           exe: ""
         - platform: linux-arm64
+          exe: ""
+        - platform: linux-arm
           exe: ""
         - platform: darwin
           exe: ""

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # linkerd-buoyant
 
-![Actions](https://github.com/BuoyantIO/linkerd-buoyant/workflows/Actions/badge.svg?branch=main)
+[![Actions](https://github.com/BuoyantIO/linkerd-buoyant/actions/workflows/actions.yml/badge.svg)](https://github.com/BuoyantIO/linkerd-buoyant/actions/workflows/actions.yml)
+[![Go Report Card](https://goreportcard.com/badge/github.com/buoyantio/linkerd-buoyant)](https://goreportcard.com/report/github.com/buoyantio/linkerd-buoyant)
+[![GitHub license](https://img.shields.io/github/license/buoyantio/linkerd-buoyant.svg)](LICENSE)
 
 The Linkerd Buoyant extension is a CLI tool for managing the Buoyant Cloud
 Agent.

--- a/pkg/k8s/mock_client.go
+++ b/pkg/k8s/mock_client.go
@@ -8,6 +8,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 )
 
+// MockClient provides a mock Kubernetes client for testing
 type MockClient struct {
 	MockNamespace          *v1.Namespace
 	MockClusterRole        *rbacv1.ClusterRole
@@ -21,31 +22,47 @@ type MockClient struct {
 	MockResources []string
 }
 
+// Namespace returns a mock Namespace object.
 func (m *MockClient) Namespace(ctx context.Context) (*v1.Namespace, error) {
 	return m.MockNamespace, nil
 }
+
+// ClusterRole returns a mock ClusterRole object.
 func (m *MockClient) ClusterRole(ctx context.Context) (*rbacv1.ClusterRole, error) {
 	return m.MockClusterRole, nil
 }
+
+// ClusterRoleBinding returns a mock ClusterRoleBinding object.
 func (m *MockClient) ClusterRoleBinding(ctx context.Context) (*rbacv1.ClusterRoleBinding, error) {
 	return m.MockClusterRoleBinding, nil
 }
+
+// Secret returns a mock Secret object.
 func (m *MockClient) Secret(ctx context.Context) (*v1.Secret, error) {
 	return m.MockSecret, nil
 }
+
+// ServiceAccount returns a mock ServiceAccount object.
 func (m *MockClient) ServiceAccount(ctx context.Context) (*v1.ServiceAccount, error) {
 	return m.MockServiceAccount, nil
 }
+
+// Deployment returns a mock Deployment object.
 func (m *MockClient) Deployment(ctx context.Context, name string) (*appsv1.Deployment, error) {
 	return m.MockDeployment, nil
 }
+
+// Pods returns a mock Pod List.
 func (m *MockClient) Pods(ctx context.Context, labelSelector string) (*v1.PodList, error) {
 	return m.MockPods, nil
 }
 
+// Agent returns a mock Buoyant Cloud Agent.
 func (m *MockClient) Agent(ctx context.Context) (*Agent, error) {
 	return m.MockAgent, nil
 }
+
+// Resources returns mock Buoyant Cloud Agent resources.
 func (m *MockClient) Resources(ctx context.Context) ([]string, error) {
 	return m.MockResources, nil
 }


### PR DESCRIPTION
Include `linkerd-arm` in the build/release matrix.

Other misc changes:
- Fix GitHub Actions badge
- Add Go Report Card and LICENSE badges
- Add comments to MockClient for linting

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

<img width="1017" alt="Screen Shot 2021-02-23 at 3 19 21 PM" src="https://user-images.githubusercontent.com/236915/108921010-8ccd6480-75ea-11eb-8ebb-61be83028aae.png">
