### PR TITLE
Introduce online version check

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -20,7 +20,7 @@ jobs:
     name: Go Unit Tests
     runs-on: ubuntu-20.04
     container:
-      image: golang:1.15.8
+      image: golang:1.16.0
     steps:
     - name: Checkout Code
       uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs:
     name: Go Lint
     runs-on: ubuntu-20.04
     container:
-      image: golang:1.15.8
+      image: golang:1.16.0
     steps:
     - name: Checkout Code
       uses: actions/checkout@v2
@@ -67,7 +67,7 @@ jobs:
           goarch: ""
           exe: .exe
     container:
-      image: golang:1.15.8
+      image: golang:1.16.0
     steps:
     - name: Checkout Code
       uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Agent.
 To install the CLI, run:
 
 ```bash
-curl https://buoyant.cloud/install | sh
+curl -sL https://buoyant.cloud/install | sh
 ```
 
 Alternatively, you can download the CLI directly via the
@@ -22,20 +22,20 @@ Alternatively, you can download the CLI directly via the
 
 ```bash
 $ linkerd-buoyant
-linkerd-buoyant manages the Buoyant Cloud Agent.
+linkerd-buoyant manages the Buoyant Cloud agent.
 
-It enables operational control over the Buoyant Cloud Agent, providing install,
-upgrade, and delete functionality
+It enables operational control over the Buoyant Cloud agent, providing install,
+upgrade, and delete functionality.
 
 Usage:
   linkerd-buoyant [command]
 
 Available Commands:
-  check       Check the Buoyant Cloud Agent installation for potential problems
+  check       Check the Buoyant Cloud agent installation for potential problems
   help        Help about any command
-  install     Output Buoyant Cloud Agent manifest for installation
-  uninstall   Output Kubernetes resources to uninstall the Buoyant Cloud Agent
-  version     Print the CLI and Agent version information
+  install     Output Buoyant Cloud agent manifest for installation
+  uninstall   Output Kubernetes manifest to uninstall the Buoyant Cloud agent
+  version     Print the CLI and agent version information
 
 Flags:
       --context string      The name of the kubeconfig context to use

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"time"
 
@@ -23,11 +24,11 @@ func newCmdCheck(cfg *config) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "check [flags]",
 		Args:  cobra.NoArgs,
-		Short: "Check the Buoyant Cloud Agent installation for potential problems",
-		Long: `Check the Buoyant Cloud Agent installation for potential problems.
+		Short: "Check the Buoyant Cloud agent installation for potential problems",
+		Long: `Check the Buoyant Cloud agent installation for potential problems.
 
 The check command will perform a series of checks to validate that the
-linkerd-buoyant CLI and Buoyant Cloud Agent are configured correctly. If the
+linkerd-buoyant CLI and Buoyant Cloud agent are configured correctly. If the
 command encounters a failure it will print additional information about the
 failure and exit with a non-zero exit code.`,
 		Example: `  # Default check.
@@ -60,7 +61,7 @@ failure and exit with a non-zero exit code.`,
 	return cmd
 }
 
-func check(cfg *checkConfig, client k8s.Client) error {
+func check(cfg *checkConfig, k8s k8s.Client) error {
 	if cfg.output != healthcheck.TableOutput && cfg.output != healthcheck.JSONOutput {
 		return fmt.Errorf(
 			"Invalid output type '%s'. Supported output types are: %s, %s",
@@ -69,10 +70,12 @@ func check(cfg *checkConfig, client k8s.Client) error {
 	}
 
 	hc := pkghealthcheck.NewHealthChecker(
-		client,
 		&healthcheck.Options{
 			RetryDeadline: time.Now().Add(cfg.wait),
 		},
+		k8s,
+		http.DefaultClient,
+		cfg.bcloudServer,
 	)
 
 	hc.AppendCategories(hc.L5dBuoyantCategory())

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -24,8 +24,8 @@ func newCmdInstall(cfg *config) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "install [flags]",
 		Args:  cobra.NoArgs,
-		Short: "Output Buoyant Cloud Agent manifest for installation",
-		Long: `Output Buoyant Cloud Agent manifest for installation.
+		Short: "Output Buoyant Cloud agent manifest for installation",
+		Long: `Output Buoyant Cloud agent manifest for installation.
 
 This command provides the Kubernetes configs necessary to install the Buoyant
 Cloud Agent.
@@ -101,7 +101,7 @@ func install(ctx context.Context, cfg *config, client k8s.Client, openURL openUR
 	// output the YAML manifest, this is the only thing that outputs to stdout
 	fmt.Fprintf(cfg.stdout, "%s\n", body)
 
-	fmt.Fprintf(cfg.stderr, "Agent manifest available at:\n%s\n", agentURL)
+	fmt.Fprintf(cfg.stderr, "Agent manifest available at:\n%s\n\n", agentURL)
 
 	return nil
 }
@@ -112,9 +112,9 @@ func newAgentURL(cfg *config, openURL openURL) (string, error) {
 	connectURL := fmt.Sprintf("%s/connect-cluster?linkerd-buoyant=%s", cfg.bcloudServer, agentUID)
 	err := openURL(connectURL)
 	if err == nil {
-		fmt.Fprintf(cfg.stderr, "Opening linkerd-buoyant agent setup at:\n%s\n", connectURL)
+		fmt.Fprintf(cfg.stderr, "Opening Buoyant Cloud agent setup at:\n%s\n", connectURL)
 	} else {
-		fmt.Fprintf(cfg.stderr, "Visit this URL to set up linkerd-buoyant agent:\n%s\n\n", connectURL)
+		fmt.Fprintf(cfg.stderr, "Visit this URL to set up the Buoyant Cloud agent:\n%s\n\n", connectURL)
 	}
 
 	// start polling

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/buoyantio/linkerd-buoyant/pkg/k8s"
+	"github.com/buoyantio/linkerd-buoyant/pkg/version"
 )
 
 func TestInstallNewAgent(t *testing.T) {
@@ -24,7 +25,7 @@ func TestInstallNewAgent(t *testing.T) {
 			switch r.URL.Path {
 			case "/connect-agent":
 				connectRequests++
-				agentUID = r.URL.Query().Get("linkerd-buoyant")
+				agentUID = r.URL.Query().Get(version.LinkerdBuoyant)
 				if connectRequests == 1 {
 					w.WriteHeader(http.StatusAccepted)
 					return

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/buoyantio/linkerd-buoyant/pkg/version"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/util/homedir"
@@ -20,12 +21,12 @@ func Root() *cobra.Command {
 	}
 
 	root := &cobra.Command{
-		Use:   "linkerd-buoyant",
+		Use:   version.LinkerdBuoyant,
 		Short: "Manage the Linkerd Buoyant extension",
-		Long: `linkerd-buoyant manages the Buoyant Cloud Agent.
+		Long: `linkerd-buoyant manages the Buoyant Cloud agent.
 
-It enables operational control over the Buoyant Cloud Agent, providing install,
-upgrade, and delete functionality`,
+It enables operational control over the Buoyant Cloud agent, providing install,
+upgrade, and delete functionality.`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			return nil
 		},

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -12,8 +12,8 @@ func newCmdUninstall(cfg *config) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "uninstall [flags]",
 		Args:  cobra.NoArgs,
-		Short: "Output Kubernetes resources to uninstall the Buoyant Cloud Agent",
-		Long: `Output Kubernetes resources to uninstall the Buoyant Cloud Agent.
+		Short: "Output Kubernetes manifest to uninstall the Buoyant Cloud agent",
+		Long: `Output Kubernetes manifest to uninstall the Buoyant Cloud agent.
 
 This command provides all Kubernetes namespace-scoped and cluster-scoped
 resources (e.g Namespace, RBACs, etc.) necessary to uninstall the Buoyant Cloud
@@ -62,7 +62,7 @@ func uninstall(ctx context.Context, cfg *config, client k8s.Client) error {
 
 	// if agent is present, output its name and URL for posterity
 	if agent != nil {
-		fmt.Fprintf(cfg.stderr, "Agent manifest will remain available at:\n%s\n", agent.URL)
+		fmt.Fprintf(cfg.stderr, "Agent manifest will remain available at:\n%s\n\n", agent.URL)
 	}
 
 	return nil

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -21,7 +21,7 @@ func newCmdVersion(cfg *config) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version [flags]",
 		Args:  cobra.NoArgs,
-		Short: "Print the CLI and Agent version information",
+		Short: "Print the CLI and agent version information",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if versionCfg.cli {
 				return versionCmd(cmd.Context(), versionCfg, nil)
@@ -56,11 +56,10 @@ func versionCmd(
 
 	agent, err := client.Agent(ctx)
 	if err != nil {
-		fmt.Fprintf(cfg.stderr, "Failed to get Agent version: %s\n", err)
-		return err
+		cfg.printVerbosef("Failed to get Agent version: %s\n", err)
 	}
 
-	agentVersion := "not found"
+	agentVersion := "unavailable"
 	if agent != nil {
 		agentVersion = agent.Version
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buoyantio/linkerd-buoyant
 
-go 1.15
+go 1.16
 
 require (
 	github.com/fatih/color v1.9.0

--- a/pkg/k8s/agent.go
+++ b/pkg/k8s/agent.go
@@ -20,7 +20,7 @@ const (
 	agentSecret = "buoyant-cloud-id"
 )
 
-// Agent represents the linkerd-buoyant agent. Any of these fields may not be
+// Agent represents the Buoyant Cloud agent. Any of these fields may not be
 // present, depending on which resources are already on the cluster.
 type Agent struct {
 	Name    string

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -30,7 +30,7 @@ type (
 		// namespace.
 		Pods(ctx context.Context, labelSelector string) (*v1.PodList, error)
 
-		// Agent retrieves the Buoyant Cloud Agent from Kubernetes, and returns the
+		// Agent retrieves the Buoyant Cloud agent from Kubernetes, and returns the
 		// agent's name, version, and url. If Agent is not found, it will return a
 		// nil Agent with no error.
 		Agent(ctx context.Context) (*Agent, error)

--- a/pkg/k8s/mock_client.go
+++ b/pkg/k8s/mock_client.go
@@ -57,12 +57,12 @@ func (m *MockClient) Pods(ctx context.Context, labelSelector string) (*v1.PodLis
 	return m.MockPods, nil
 }
 
-// Agent returns a mock Buoyant Cloud Agent.
+// Agent returns a mock Buoyant Cloud agent.
 func (m *MockClient) Agent(ctx context.Context) (*Agent, error) {
 	return m.MockAgent, nil
 }
 
-// Resources returns mock Buoyant Cloud Agent resources.
+// Resources returns mock Buoyant Cloud agent resources.
 func (m *MockClient) Resources(ctx context.Context) ([]string, error) {
 	return m.MockResources, nil
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,7 +1,55 @@
 package version
 
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+// LinkerdBuoyant defines the name of the CLI application.
+const LinkerdBuoyant = "linkerd-buoyant"
+
 // Version is updated automatically as part of the build process, and is the
 // ground source of truth for the current process's build version.
 //
 // DO NOT EDIT
 var Version = "undefined"
+
+// Get retrieves the current linkerd-buoyant version from the Buoyant Cloud
+// server.
+func Get(ctx context.Context, client *http.Client, url string) (string, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return "", err
+	}
+
+	rsp, err := client.Do(req.WithContext(ctx))
+	if err != nil {
+		return "", err
+	}
+	defer rsp.Body.Close()
+
+	if rsp.StatusCode != 200 {
+		return "", fmt.Errorf("unexpected version response: %s", rsp.Status)
+	}
+
+	bytes, err := ioutil.ReadAll(rsp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	var versionRsp map[string]string
+	err = json.Unmarshal(bytes, &versionRsp)
+	if err != nil {
+		return "", err
+	}
+
+	version, ok := versionRsp[LinkerdBuoyant]
+	if !ok {
+		return "", fmt.Errorf("unrecognized version response: %s", bytes)
+	}
+
+	return version, nil
+}

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,35 @@
+package version
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestVersion(t *testing.T) {
+	versionRsp := map[string]string{
+		LinkerdBuoyant: "fake-version",
+	}
+
+	j, err := json.Marshal(versionRsp)
+	if err != nil {
+		t.Fatalf("JSON marshal failed with: %s", err)
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Write(j)
+		}),
+	)
+	defer ts.Close()
+
+	version, err := Get(context.Background(), ts.Client(), ts.URL)
+	if err != nil {
+		t.Error(err)
+	}
+	if version != "fake-version" {
+		t.Errorf("Unexpected version: [%s], Expected: [fake-version]", version)
+	}
+}


### PR DESCRIPTION
The `linkerd-buoyant check` subcommand had a hard-coded version number
when determining if the CLI and agent were up to date.

Modify `linkerd-buoyant check` to hit https://buoyant.cloud/version.json
to determine the latest version.

Other misc changes:
- Bump go.mod and GitHub Actions from golang:1.15.8 to 1.16.0.
- Modify `linkerd-buoyant version` to more gracefully handle k8s server
  being unavailable.
- Misc wordsmithing.

Fixes #2

Signed-off-by: Andrew Seigner <siggy@buoyant.io>