### PR TITLE
Change check category to linkerd-buoyant

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// categoryID identifies this extension to linkerd check.
-	categoryID healthcheck.CategoryID = k8s.Namespace
+	categoryID healthcheck.CategoryID = version.LinkerdBuoyant
 )
 
 // HealthChecker wraps Linkerd's main healthchecker, adding extra fields for

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -68,8 +68,8 @@ func TestHealthChecker(t *testing.T) {
 				return hc
 			},
 			false,
-			`buoyant-cloud
--------------
+			`linkerd-buoyant
+---------------
 √ linkerd-buoyant can determine the latest version
 √ linkerd-buoyant cli is up-to-date
 √ buoyant-cloud Namespace exists
@@ -143,8 +143,8 @@ Status check results are ×
 				return hc
 			},
 			true,
-			`buoyant-cloud
--------------
+			`linkerd-buoyant
+---------------
 √ linkerd-buoyant can determine the latest version
 √ linkerd-buoyant cli is up-to-date
 √ buoyant-cloud Namespace exists


### PR DESCRIPTION
`linkerd check` outputs a check per extension, with the category being
the name of the extension. `linkerd-buoyant`s category was
`buoyant-cloud`, so it created multiple categories on the output.

Change the category from `buoyant-cloud` to `linkerd-buoyant`.

Fixes #6

Signed-off-by: Andrew Seigner <siggy@buoyant.io>