### PR TITLE
Add retries to the install subcommand polling

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -20,6 +20,8 @@ import (
 // a browser window.
 type openURL func(url string) error
 
+const maxPollingRetries = 3
+
 func newCmdInstall(cfg *config) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "install [flags]",
@@ -148,7 +150,7 @@ func newAgentURL(cfg *config, openURL openURL) (string, error) {
 
 		if resp.StatusCode != http.StatusPermanentRedirect {
 			retries++
-			if retries < 3 {
+			if retries < maxPollingRetries {
 				continue
 			}
 

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -130,6 +130,8 @@ func newAgentURL(cfg *config, openURL openURL) (string, error) {
 	connectAgentURL := fmt.Sprintf("%s/connect-agent?linkerd-buoyant=%s", cfg.bcloudServer, agentUID)
 	cfg.printVerbosef("Polling: %s", connectAgentURL)
 
+	// only exit on 3 consecutive failures
+	retries := 0
 	for {
 		resp, err := client.Get(connectAgentURL)
 		if err != nil {
@@ -139,11 +141,17 @@ func newAgentURL(cfg *config, openURL openURL) (string, error) {
 
 		if resp.StatusCode == http.StatusAccepted {
 			// still polling
+			retries = 0
 			time.Sleep(time.Second)
 			continue
 		}
 
 		if resp.StatusCode != http.StatusPermanentRedirect {
+			retries++
+			if retries < 3 {
+				continue
+			}
+
 			return "", fmt.Errorf("setup failed, unexpected HTTP status code %d for URL %s", resp.StatusCode, connectAgentURL)
 		}
 

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -31,6 +31,11 @@ func TestInstallNewAgent(t *testing.T) {
 					return
 				}
 
+				if connectRequests == 2 {
+					w.WriteHeader(http.StatusBadGateway)
+					return
+				}
+
 				http.Redirect(w, r, "/agent-yaml-redirect", http.StatusPermanentRedirect)
 			case "/agent-yaml-redirect":
 				redirectRequests++
@@ -62,14 +67,54 @@ func TestInstallNewAgent(t *testing.T) {
 	if !strings.Contains(stderr.String(), expBrowserURL) {
 		t.Errorf("Expected stderr to contain [%s], Got: [%s]", expBrowserURL, stderr.String())
 	}
-	if totalRequests != 3 {
-		t.Errorf("Expected 3 total requests, called %d times", totalRequests)
+	if totalRequests != 4 {
+		t.Errorf("Expected 4 total requests, called %d times", totalRequests)
 	}
-	if connectRequests != 2 {
-		t.Errorf("Expected 2 /connect-agent requests, called %d times", connectRequests)
+	if connectRequests != 3 {
+		t.Errorf("Expected 3 /connect-agent requests, called %d times", connectRequests)
 	}
 	if redirectRequests != 1 {
 		t.Errorf("Expected 1 /agent-yaml-redirect request, called %d times", redirectRequests)
+	}
+}
+
+func TestInstalWithPollingFailures(t *testing.T) {
+	totalRequests := 0
+	connectRequests := 0
+	agentUID := "'"
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			totalRequests++
+			switch r.URL.Path {
+			case "/connect-agent":
+				agentUID = r.URL.Query().Get(version.LinkerdBuoyant)
+				connectRequests++
+				w.WriteHeader(http.StatusBadGateway)
+			}
+		},
+	))
+	defer ts.Close()
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cfg := &config{
+		stdout:       stdout,
+		stderr:       stderr,
+		bcloudServer: ts.URL,
+	}
+
+	client := &k8s.MockClient{}
+	err := install(context.TODO(), cfg, client, mockOpenURL)
+	expErr := fmt.Errorf("setup failed, unexpected HTTP status code 502 for URL %s/connect-agent?linkerd-buoyant=%s", ts.URL, agentUID)
+	if !reflect.DeepEqual(err, expErr) {
+		t.Errorf("Expected error: %s, Got: %s", expErr, err)
+	}
+
+	if totalRequests != 3 {
+		t.Errorf("Expected 3 total requests, called %d times", totalRequests)
+	}
+	if connectRequests != 3 {
+		t.Errorf("Expected 3 /connect-agent requests, called %d times", connectRequests)
 	}
 }
 

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -110,11 +110,11 @@ func TestInstalWithPollingFailures(t *testing.T) {
 		t.Errorf("Expected error: %s, Got: %s", expErr, err)
 	}
 
-	if totalRequests != 3 {
-		t.Errorf("Expected 3 total requests, called %d times", totalRequests)
+	if totalRequests != maxPollingRetries {
+		t.Errorf("Expected %d total requests, called %d times", maxPollingRetries, totalRequests)
 	}
-	if connectRequests != 3 {
-		t.Errorf("Expected 3 /connect-agent requests, called %d times", connectRequests)
+	if connectRequests != maxPollingRetries {
+		t.Errorf("Expected %d /connect-agent requests, called %d times", maxPollingRetries, connectRequests)
 	}
 }
 


### PR DESCRIPTION
The `install` subcommand polls Buoyant Cloud once per second while the
user sets up their cluster in their browser. If a single request failed,
the CLI would exit.

Modify the `install` polling to only exit after 3 consecutive request
failures.

Fixes #9

Signed-off-by: Andrew Seigner <siggy@buoyant.io>