### PR TITLE
Add dashboard command

### DIFF
--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -1,45 +1,16 @@
 package cmd
 
 import (
-	"context"
-	"fmt"
-
-	"github.com/buoyantio/linkerd-buoyant/pkg/k8s"
-	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 )
 
-func newCmdDashboard(cfg *config) *cobra.Command {
-	cmd := &cobra.Command{
+func newCmdDashboard(cfg *config, openURL openURL) *cobra.Command {
+	return &cobra.Command{
 		Use:   "dashboard [flags]",
 		Args:  cobra.NoArgs,
-		Short: "Opens the Bcloud Dashboard",
+		Short: "Open the Buoyant Cloud dashboard",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := k8s.New(cfg.kubeconfig, cfg.kubecontext, cfg.bcloudServer)
-			if err != nil {
-				return err
-			}
-
-			return dashboardCmd(cmd.Context(), cfg, client, browser.OpenURL)
+			return openURL(cfg.bcloudServer)
 		},
 	}
-
-	return cmd
-}
-
-func dashboardCmd(
-	ctx context.Context, cfg *config, client k8s.Client, openURL openURL,
-) error {
-	agent, err := client.Agent(ctx)
-	if err != nil {
-		cfg.printVerbosef("Failed to get Agent: %s\n", err)
-		return nil
-	}
-
-	if agent == nil {
-		fmt.Fprint(cfg.stdout, "Agent not installed, run linkerd-buoyant install\n")
-		return nil
-	}
-
-	return openURL(cfg.bcloudServer)
 }

--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -10,7 +10,6 @@ import (
 )
 
 func newCmdDashboard(cfg *config) *cobra.Command {
-
 	cmd := &cobra.Command{
 		Use:   "dashboard [flags]",
 		Args:  cobra.NoArgs,
@@ -31,7 +30,6 @@ func newCmdDashboard(cfg *config) *cobra.Command {
 func dashboardCmd(
 	ctx context.Context, cfg *config, client k8s.Client, openURL openURL,
 ) error {
-
 	agent, err := client.Agent(ctx)
 	if err != nil {
 		cfg.printVerbosef("Failed to get Agent: %s\n", err)

--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/buoyantio/linkerd-buoyant/pkg/k8s"
+	"github.com/pkg/browser"
+	"github.com/spf13/cobra"
+)
+
+func newCmdDashboard(cfg *config) *cobra.Command {
+
+	cmd := &cobra.Command{
+		Use:   "dashboard [flags]",
+		Args:  cobra.NoArgs,
+		Short: "Opens the Bcloud Dashboard",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := k8s.New(cfg.kubeconfig, cfg.kubecontext, cfg.bcloudServer)
+			if err != nil {
+				return err
+			}
+
+			return dashboardCmd(cmd.Context(), cfg, client, browser.OpenURL)
+		},
+	}
+
+	return cmd
+}
+
+func dashboardCmd(
+	ctx context.Context, cfg *config, client k8s.Client, openURL openURL,
+) error {
+
+	agent, err := client.Agent(ctx)
+	if err != nil {
+		cfg.printVerbosef("Failed to get Agent: %s\n", err)
+		return nil
+	}
+
+	if agent == nil {
+		fmt.Fprint(cfg.stdout, "Agent not installed, run linkerd-buoyant install\n")
+		return nil
+	}
+
+	return openURL(cfg.bcloudServer)
+}

--- a/cmd/dashboard_test.go
+++ b/cmd/dashboard_test.go
@@ -1,41 +1,11 @@
 package cmd
 
 import (
-	"bytes"
-	"context"
 	"testing"
-
-	"github.com/buoyantio/linkerd-buoyant/pkg/k8s"
 )
 
-func TestDashboardNoAgent(t *testing.T) {
-	stdout := &bytes.Buffer{}
-
-	cfg := &config{
-		stdout:       stdout,
-		bcloudServer: "http://example.com",
-	}
-
-	client := &k8s.MockClient{
-		MockAgent: nil,
-	}
-	err := dashboardCmd(context.TODO(), cfg, client, mockOpenURL)
-	if err != nil {
-		t.Error(err)
-	}
-
-	expStdout := "Agent not installed, run linkerd-buoyant install\n"
-	if stdout.String() != expStdout {
-		t.Errorf("Expected %s, Got %s", expStdout, stdout.String())
-	}
-}
-
-func TestDashboardAgentPresent(t *testing.T) {
+func TestDashboard(t *testing.T) {
 	cfg := &config{bcloudServer: "http://example.com"}
-
-	client := &k8s.MockClient{
-		MockAgent: &k8s.Agent{},
-	}
 
 	var openedUrl string
 	mockOpen := func(url string) error {
@@ -43,12 +13,13 @@ func TestDashboardAgentPresent(t *testing.T) {
 		return nil
 	}
 
-	err := dashboardCmd(context.TODO(), cfg, client, mockOpen)
+	cmd := newCmdDashboard(cfg, mockOpen)
+	err := cmd.RunE(cmd, nil)
 	if err != nil {
 		t.Error(err)
 	}
 
 	if openedUrl != cfg.bcloudServer {
-		t.Errorf("Expected to open url %s, Got %s", cfg.bcloudServer, openedUrl)
+		t.Fatalf("Expected to open url %s, Got %s", cfg.bcloudServer, openedUrl)
 	}
 }

--- a/cmd/dashboard_test.go
+++ b/cmd/dashboard_test.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/buoyantio/linkerd-buoyant/pkg/k8s"
+)
+
+func TestDashboardNoAgent(t *testing.T) {
+	stdout := &bytes.Buffer{}
+
+	cfg := &config{
+		stdout:       stdout,
+		bcloudServer: "http://example.com",
+	}
+
+	client := &k8s.MockClient{
+		MockAgent: nil,
+	}
+	err := dashboardCmd(context.TODO(), cfg, client, mockOpenURL)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expStdout := "Agent not installed, run linkerd-buoyant install\n"
+	if stdout.String() != expStdout {
+		t.Errorf("Expected %s, Got %s", expStdout, stdout.String())
+	}
+}
+
+func TestDashboardAgentPresent(t *testing.T) {
+	cfg := &config{bcloudServer: "http://example.com"}
+
+	client := &k8s.MockClient{
+		MockAgent: &k8s.Agent{},
+	}
+
+	var openedUrl string
+	mockOpen := func(url string) error {
+		openedUrl = url
+		return nil
+	}
+
+	err := dashboardCmd(context.TODO(), cfg, client, mockOpen)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if openedUrl != cfg.bcloudServer {
+		t.Errorf("Expected to open url %s, Got %s", cfg.bcloudServer, openedUrl)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/buoyantio/linkerd-buoyant/pkg/version"
 	"github.com/fatih/color"
+	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/util/homedir"
 )
@@ -62,7 +63,7 @@ upgrade, and delete functionality.`,
 	root.AddCommand(newCmdInstall(cfg))
 	root.AddCommand(newCmdUninstall(cfg))
 	root.AddCommand(newCmdVersion(cfg))
-	root.AddCommand(newCmdDashboard(cfg))
+	root.AddCommand(newCmdDashboard(cfg, browser.OpenURL))
 
 	return root
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -62,6 +62,7 @@ upgrade, and delete functionality.`,
 	root.AddCommand(newCmdInstall(cfg))
 	root.AddCommand(newCmdUninstall(cfg))
 	root.AddCommand(newCmdVersion(cfg))
+	root.AddCommand(newCmdDashboard(cfg))
 
 	return root
 }


### PR DESCRIPTION
This PR adds a dashboard command, which opens up the Bcloud dashboard
if the agent is installed on the cluster.

Fix: #13

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>