### PR TITLE
Turn down some ManageAgent logs from info to debug

### DIFF
--- a/agent/pkg/api/manage_agent_stream.go
+++ b/agent/pkg/api/manage_agent_stream.go
@@ -36,7 +36,9 @@ func (s *manageAgentStream) startStream() {
 	for {
 		command, err := s.recvCommand()
 		if err != nil {
-			s.log.Infof("stream closed, reseting: %s", err)
+			// TODO: set this back to `Infof`:
+			// https://github.com/BuoyantIO/linkerd-buoyant/issues/21
+			s.log.Debugf("stream closed, reseting: %s", err)
 			s.resetStream()
 			continue
 		}
@@ -69,7 +71,9 @@ func (s *manageAgentStream) newStream() pb.Api_ManageAgentClient {
 		break
 	}
 
-	s.log.Info("ManageAgentStream connected")
+	// TODO: set this back to `Info`:
+	// https://github.com/BuoyantIO/linkerd-buoyant/issues/21
+	s.log.Debug("ManageAgentStream connected")
 	return stream
 }
 


### PR DESCRIPTION
The `ManageAgent` stream reconnects every 10 seconds, due to #21. While
the API will still work, it adds noise to the log.

Modify some ManageAgent logs from info to debug, until #21 is resolved.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>