### PR TITLE
Extract CP roots from config map

### DIFF
--- a/agent/pkg/handler/linkerd_info.go
+++ b/agent/pkg/handler/linkerd_info.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"time"
 
 	"github.com/buoyantio/linkerd-buoyant/agent/pkg/api"
@@ -43,7 +44,7 @@ func (h *LinkerdInfo) Start() {
 	for {
 		select {
 		case <-ticker.C:
-			h.handleCertsInfo()
+			h.handleCertsInfo(context.Background())
 		case <-h.stopCh:
 			return
 		}
@@ -56,8 +57,8 @@ func (h *LinkerdInfo) Stop() {
 	close(h.stopCh)
 }
 
-func (h *LinkerdInfo) handleCertsInfo() {
-	certs, err := h.k8s.GetControlPlaneCerts()
+func (h *LinkerdInfo) handleCertsInfo(ctx context.Context) {
+	certs, err := h.k8s.GetControlPlaneCerts(ctx)
 	if err != nil {
 		h.log.Errorf("error getting control plane certs: %s", err)
 		return

--- a/agent/pkg/k8s/certificates.go
+++ b/agent/pkg/k8s/certificates.go
@@ -1,7 +1,9 @@
 package k8s
 
 import (
+	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"net"
 	"time"
@@ -11,6 +13,7 @@ import (
 	l5dk8s "github.com/linkerd/linkerd2/pkg/k8s"
 	ldTls "github.com/linkerd/linkerd2/pkg/tls"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
@@ -18,9 +21,11 @@ const (
 	identityComponentName        = "identity"
 	linkerdNsEnvVarName          = "_l5d_ns"
 	linkerdTrustDomainEnvVarName = "_l5d_trustdomain"
+	trustRootsConfigMapName      = "linkerd-identity-trust-roots"
+	trustRootsConfigMapKeyName   = "ca-bundle.crt"
 )
 
-func (c *Client) GetControlPlaneCerts() (*pb.ControlPlaneCerts, error) {
+func (c *Client) GetControlPlaneCerts(ctx context.Context) (*pb.ControlPlaneCerts, error) {
 	identityPod, err := c.getControlPlaneComponentPod(identityComponentName)
 	if err != nil {
 		return nil, err
@@ -31,7 +36,7 @@ func (c *Client) GetControlPlaneCerts() (*pb.ControlPlaneCerts, error) {
 		return nil, err
 	}
 
-	rootCerts, err := extractRootsCerts(container)
+	rootCerts, err := c.extractRootsCerts(ctx, container, identityPod.Namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -95,15 +100,41 @@ func getServerName(podsa string, podns string, container *v1.Container) (string,
 	return fmt.Sprintf("%s.%s.serviceaccount.identity.%s.%s", podsa, podns, l5dns, l5dtrustdomain), nil
 }
 
-func extractRootsCerts(container *v1.Container) ([]*pb.CertData, error) {
+func (c *Client) extractRootsCerts(ctx context.Context, container *v1.Container, namespace string) ([]*pb.CertData, error) {
 	for _, ev := range container.Env {
 		if ev.Name != identity.EnvTrustAnchors {
 			continue
 		}
-		certificates, err := ldTls.DecodePEMCertificates(ev.Value)
-		if err != nil {
-			return nil, err
+
+		var certificates []*x509.Certificate
+		var err error
+		if ev.Value != "" {
+			certificates, err = ldTls.DecodePEMCertificates(ev.Value)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			// in this case we need to check for a reference to a config map
+			if ev.ValueFrom == nil || ev.ValueFrom.ConfigMapKeyRef == nil {
+				return nil, fmt.Errorf("neither a Value nor a ConfigMapKeyRef for the %s env var arepresent on proxy container [%s]", identity.EnvTrustAnchors, container.Name)
+			}
+			cmName := ev.ValueFrom.ConfigMapKeyRef.Name
+			cm, err := c.k8sClient.CoreV1().ConfigMaps(namespace).Get(ctx, cmName, metav1.GetOptions{})
+			if err != nil {
+				return nil, fmt.Errorf("cannot obtain config map %s/%s", namespace, cmName)
+			}
+
+			rootsValue, ok := cm.Data[trustRootsConfigMapKeyName]
+			if !ok {
+				return nil, fmt.Errorf("config map %s/%s does not have %s key", namespace, cmName, trustRootsConfigMapKeyName)
+			}
+
+			certificates, err = ldTls.DecodePEMCertificates(rootsValue)
+			if err != nil {
+				return nil, err
+			}
 		}
+
 		certsData := make([]*pb.CertData, len(certificates))
 		for i, crt := range certificates {
 			encoded := ldTls.EncodeCertificatesPEM(crt)


### PR DESCRIPTION
When running with the latest Linkerd edge bloud agent is sending a certificate message with the Roots being empty. The reason for that is that in the bcloud agent, we look for the `EnvVar.Value` field rather than the `EnvVar.ValueFrom`. In https://github.com/linkerd/linkerd2/pull/6455 the proxy manifest was changed to load the trust anchors from a config map. This causes the described above problem. 

This can be fixed by making the agent consider this value when inspecting the env vars. It is important to make this backwards compatible - check the `Value` field and only if not present, check the `ValueFrom` one. This might require RBAC changes.

Note to reviewers: 

In order to test, run this agent with the latest stable to ensure the change is backwards compatible. After that you can run it with the latest edge to convince yourself that the problem has been fixed. In both cases you need to make sure that the certificates in the control plane page are populated.


Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>