### PR TITLE
Upgrade to Go 1.17, add tools.go

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -20,7 +20,7 @@ jobs:
     name: Go Unit Tests
     runs-on: ubuntu-20.04
     container:
-      image: golang:1.16.5
+      image: golang:1.17.0
     steps:
     - name: Checkout Code
       uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs:
     name: Go Lint
     runs-on: ubuntu-20.04
     container:
-      image: golang:1.16.5
+      image: golang:1.17.0
     steps:
     - name: Checkout Code
       uses: actions/checkout@v2
@@ -71,7 +71,7 @@ jobs:
           goarch: ""
           exe: .exe
     container:
-      image: golang:1.16.5
+      image: golang:1.17.0
     steps:
     - name: Checkout Code
       uses: actions/checkout@v2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 # This file specifies which linters golangci-lint should run.
 #
 # For descriptions of all available linters, run:
-# ./target/bin/.golangci-lint-1.32.2 linters
+# ./target/bin/.golangci-lint-1.42.0 linters
 # or browse to:
 # https://github.com/golangci/golangci-lint#supported-linters
 
@@ -16,6 +16,7 @@ linters:
   - deadcode
   - depguard
   - dogsled
+  - errname
   - exportloopref
   - goconst
   - goheader

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.5-buster as golang
+FROM golang:1.17.0-buster as golang
 
 WORKDIR /bcloud-build
 
@@ -12,7 +12,7 @@ COPY gen           gen
 RUN CGO_ENABLED=0 GOOS=linux go build -o /bcloud-agent -mod=readonly agent/main.go
 
 
-FROM debian:buster-20210621-slim
+FROM debian:buster-20210816-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates \

--- a/bin/lint
+++ b/bin/lint
@@ -2,7 +2,7 @@
 
 set -eu
 
-lintversion=1.41.1
+lintversion=1.42.0
 
 cd "$(pwd -P)"
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buoyantio/linkerd-buoyant
 
-go 1.16
+go 1.17
 
 require (
 	github.com/fatih/color v1.12.0
@@ -9,7 +9,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.2.1
 	google.golang.org/grpc v1.39.0
-	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0 // indirect
+	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0
 	google.golang.org/protobuf v1.27.1
 	k8s.io/api v0.21.2
 	k8s.io/apimachinery v0.21.2
@@ -17,4 +17,81 @@ require (
 	k8s.io/klog v1.0.0
 	k8s.io/kubectl v0.21.2
 	sigs.k8s.io/yaml v1.2.0
+)
+
+require (
+	cloud.google.com/go v0.81.0 // indirect
+	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
+	github.com/Azure/go-autorest/autorest v0.11.12 // indirect
+	github.com/Azure/go-autorest/autorest/adal v0.9.5 // indirect
+	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
+	github.com/Azure/go-autorest/logger v0.2.0 // indirect
+	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
+	github.com/BurntSushi/toml v0.3.1 // indirect
+	github.com/Masterminds/goutils v1.1.0 // indirect
+	github.com/Masterminds/semver/v3 v3.1.0 // indirect
+	github.com/Masterminds/sprig/v3 v3.1.0 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/briandowns/spinner v0.0.0-20190212173954-5cf08d0ac778 // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/cyphar/filepath-securejoin v0.2.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/evanphx/json-patch v4.9.0+incompatible // indirect
+	github.com/form3tech-oss/jwt-go v3.2.2+incompatible // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/go-logr/logr v0.4.0 // indirect
+	github.com/gobwas/glob v0.2.3 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/go-cmp v0.5.5 // indirect
+	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/google/uuid v1.1.2 // indirect
+	github.com/googleapis/gnostic v0.4.1 // indirect
+	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
+	github.com/hashicorp/golang-lru v0.5.1 // indirect
+	github.com/huandu/xstrings v1.3.1 // indirect
+	github.com/imdario/mergo v0.3.8 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/json-iterator/go v1.1.11 // indirect
+	github.com/linkerd/linkerd2-proxy-api v0.1.16 // indirect
+	github.com/mattn/go-colorable v0.1.8 // indirect
+	github.com/mattn/go-isatty v0.0.12 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
+	github.com/mitchellh/copystructure v1.0.0 // indirect
+	github.com/mitchellh/reflectwalk v1.0.0 // indirect
+	github.com/moby/spdystream v0.2.0 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/prometheus/client_golang v1.7.1 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.10.0 // indirect
+	github.com/prometheus/procfs v0.2.0 // indirect
+	github.com/servicemeshinterface/smi-sdk-go v0.4.1 // indirect
+	github.com/spf13/cast v1.3.1 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
+	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
+	go.opencensus.io v0.23.0 // indirect
+	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83 // indirect
+	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
+	golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602 // indirect
+	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
+	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
+	golang.org/x/text v0.3.5 // indirect
+	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	helm.sh/helm/v3 v3.4.1 // indirect
+	k8s.io/apiextensions-apiserver v0.19.3 // indirect
+	k8s.io/klog/v2 v2.8.0 // indirect
+	k8s.io/kube-aggregator v0.18.8 // indirect
+	k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7 // indirect
+	k8s.io/utils v0.0.0-20201110183641-67b214c5f920 // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.1.0 // indirect
 )

--- a/tools.go
+++ b/tools.go
@@ -1,0 +1,7 @@
+// +build tools
+
+package tools
+
+import (
+	_ "google.golang.org/grpc/cmd/protoc-gen-go-grpc"
+)


### PR DESCRIPTION
Upgrade code, actions, and Dockerfile to Go 1.17.

Other changes:
- Introduce `tools.go`, to prevent `go.mod` jitter (#20)
- Upgrade golangci-lint from `1.41.1` to `1.42.0`, add `errname` linter
- Bump base Docker image from `debian:buster-20210621-slim` to
  `20210816`

Fixes BuoyantIO/bcloud#5884

Signed-off-by: Andrew Seigner <siggy@buoyant.io>