### PR TITLE
delay sending of events

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -44,6 +44,7 @@ func main() {
 	logLevel := flag.String("log-level", "info", "log level, must be one of: panic, fatal, error, warn, info, debug, trace")
 	localMode := flag.Bool("local-mode", false, "enable port forwarding for local development")
 	insecure := flag.Bool("insecure", false, "disable TLS in development mode")
+	eventsDelaySeconds := flag.Int64("events-delay-seconds", 60, "configures the initial delay before events start being sent")
 
 	// klog flags
 	klog.InitFlags(nil)
@@ -147,7 +148,7 @@ func main() {
 	apiClient := api.NewClient(id, key, bcloudClient)
 
 	// create handlers
-	eventHandler := handler.NewEvent(k8sClient, apiClient)
+	eventHandler := handler.NewEvent(k8sClient, apiClient, time.Duration(*eventsDelaySeconds)*time.Second)
 	workloadHandler := handler.NewWorkload(k8sClient, apiClient)
 
 	linkerdInfoHandler := handler.NewLinkerdInfo(k8sClient, apiClient)

--- a/agent/pkg/handler/event_test.go
+++ b/agent/pkg/handler/event_test.go
@@ -135,7 +135,7 @@ func TestEvent(t *testing.T) {
 			m := &api.MockBcloudClient{}
 			apiClient := api.NewClient("", "", m)
 
-			eh := NewEvent(k8sClient, apiClient)
+			eh := NewEvent(k8sClient, apiClient, 1*time.Microsecond)
 			if len(m.Events()) != 0 {
 				t.Errorf("Expected no events sent, got %d", len(m.Events()))
 			}


### PR DESCRIPTION
This PR introduces a delay parameter that is used to delay starting
the events informer. This is done to aleviate the situation described in
https://github.com/BuoyantIO/bcloud/issues/1382


An alternative method would be to introduce some kind of synchronization
between the two streams but I am a bit hesitant to do that.

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>