### PR TITLE
Update cli to check for metrics agent DaemonSet

### DIFF
--- a/cli/pkg/healthcheck/healthcheck_test.go
+++ b/cli/pkg/healthcheck/healthcheck_test.go
@@ -75,7 +75,7 @@ func TestHealthChecker(t *testing.T) {
 √ buoyant-cloud Namespace exists
 × buoyant-cloud Namespace has correct labels
     missing linkerd.io/extension label
-    see https://linkerd.io/2/checks/# for hints
+    see https://linkerd.io/checks#l5d-buoyant for hints
 
 Status check results are ×
 `,
@@ -115,6 +115,9 @@ Status check results are ×
 						},
 						MockServiceAccount: &v1.ServiceAccount{
 							ObjectMeta: objMeta,
+						},
+						MockDaemonSet: &appsv1.DaemonSet{
+							ObjectMeta: objMetaDeploy,
 						},
 						MockDeployment: &appsv1.Deployment{
 							ObjectMeta: objMetaDeploy,
@@ -157,11 +160,12 @@ Status check results are ×
 √ buoyant-cloud-agent Deployment exists
 √ buoyant-cloud-agent Deployment is running
 √ buoyant-cloud-agent Deployment is injected
-√ buoyant-cloud-agent is up-to-date
-√ buoyant-cloud-metrics Deployment exists
-√ buoyant-cloud-metrics Deployment is running
-√ buoyant-cloud-metrics Deployment is injected
-√ buoyant-cloud-metrics is up-to-date
+√ buoyant-cloud-agent Deployment is up-to-date
+√ buoyant-cloud-agent Deployment is running a single pod
+√ buoyant-cloud-metrics DaemonSet exists
+√ buoyant-cloud-metrics DaemonSet is running
+√ buoyant-cloud-metrics DaemonSet is injected
+√ buoyant-cloud-metrics DaemonSet is up-to-date
 
 Status check results are √
 `,

--- a/cli/pkg/k8s/client.go
+++ b/cli/pkg/k8s/client.go
@@ -24,6 +24,8 @@ type (
 		Secret(ctx context.Context) (*v1.Secret, error)
 		// ServiceAccount retrieves the buoyant-cloud-agent ServiceAccount.
 		ServiceAccount(ctx context.Context) (*v1.ServiceAccount, error)
+		// DaemonSet retrieves a DaemonSet by name in the buoyant-cloud namespace.
+		DaemonSet(ctx context.Context, name string) (*appsv1.DaemonSet, error)
 		// Deployment retrieves a Deployment by name in the buoyant-cloud namespace.
 		Deployment(ctx context.Context, name string) (*appsv1.Deployment, error)
 		// Pods retrieves a PodList by labelSelector from the buoyant-cloud
@@ -105,6 +107,13 @@ func (c *client) ServiceAccount(ctx context.Context) (*v1.ServiceAccount, error)
 		CoreV1().
 		ServiceAccounts(Namespace).
 		Get(ctx, AgentName, metav1.GetOptions{})
+}
+
+func (c *client) DaemonSet(ctx context.Context, name string) (*appsv1.DaemonSet, error) {
+	return c.
+		AppsV1().
+		DaemonSets(Namespace).
+		Get(ctx, name, metav1.GetOptions{})
 }
 
 func (c *client) Deployment(ctx context.Context, name string) (*appsv1.Deployment, error) {

--- a/cli/pkg/k8s/mock_client.go
+++ b/cli/pkg/k8s/mock_client.go
@@ -15,6 +15,7 @@ type MockClient struct {
 	MockClusterRoleBinding *rbacv1.ClusterRoleBinding
 	MockSecret             *v1.Secret
 	MockServiceAccount     *v1.ServiceAccount
+	MockDaemonSet          *appsv1.DaemonSet
 	MockDeployment         *appsv1.Deployment
 	MockPods               *v1.PodList
 
@@ -45,6 +46,11 @@ func (m *MockClient) Secret(ctx context.Context) (*v1.Secret, error) {
 // ServiceAccount returns a mock ServiceAccount object.
 func (m *MockClient) ServiceAccount(ctx context.Context) (*v1.ServiceAccount, error) {
 	return m.MockServiceAccount, nil
+}
+
+// DaemonSet returns a mock DaemonSet object.
+func (m *MockClient) DaemonSet(ctx context.Context, name string) (*appsv1.DaemonSet, error) {
+	return m.MockDaemonSet, nil
 }
 
 // Deployment returns a mock Deployment object.


### PR DESCRIPTION
The `v0.4.3` agent release modified `buoyant-cloud-metrics` to be a
DaemonSet rather than a Deployment. The `linkerd-buoyant check` command
was not updated to check for this.

Modify `linkerd-buoyant check` to check for a DaemonSet instead.

Also modify the check hint URL to point to `linkerd-buoyant`-specific
documentation.

Fixes #30

Signed-off-by: Andrew Seigner <siggy@buoyant.io>