### PR TITLE
Modify `dashboard` cmd to handle browser failure

### DIFF
--- a/cli/cmd/dashboard.go
+++ b/cli/cmd/dashboard.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
@@ -10,7 +12,15 @@ func newCmdDashboard(cfg *config, openURL openURL) *cobra.Command {
 		Args:  cobra.NoArgs,
 		Short: "Open the Buoyant Cloud dashboard",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return openURL(cfg.bcloudServer)
+			fmt.Fprintln(cfg.stdout, "Opening Buoyant Cloud dashboard in the default browser")
+
+			err := openURL(cfg.bcloudServer)
+			if err != nil {
+				fmt.Fprintln(cfg.stderr, "Failed to open dashboard automatically")
+				fmt.Fprintf(cfg.stderr, "Visit %s in your browser to view the dashboard\n", cfg.bcloudServer)
+			}
+
+			return nil
 		},
 	}
 }

--- a/cli/cmd/dashboard_test.go
+++ b/cli/cmd/dashboard_test.go
@@ -1,11 +1,20 @@
 package cmd
 
 import (
+	"bytes"
+	"errors"
+	"strings"
 	"testing"
 )
 
 func TestDashboard(t *testing.T) {
-	cfg := &config{bcloudServer: "http://example.com"}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cfg := &config{
+		stdout:       stdout,
+		stderr:       stderr,
+		bcloudServer: "http://example.com",
+	}
 
 	var openedUrl string
 	mockOpen := func(url string) error {
@@ -21,5 +30,29 @@ func TestDashboard(t *testing.T) {
 
 	if openedUrl != cfg.bcloudServer {
 		t.Fatalf("Expected to open url %s, Got %s", cfg.bcloudServer, openedUrl)
+	}
+}
+
+func TestDashboardFailure(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cfg := &config{
+		stdout:       stdout,
+		stderr:       stderr,
+		bcloudServer: "http://example.com",
+	}
+
+	mockOpen := func(string) error {
+		return errors.New("browser failuer")
+	}
+
+	cmd := newCmdDashboard(cfg, mockOpen)
+	err := cmd.RunE(cmd, nil)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !strings.Contains(stderr.String(), cfg.bcloudServer) {
+		t.Errorf("Expected stderr to contain [%s], Got: [%s]", cfg.bcloudServer, stderr.String())
 	}
 }


### PR DESCRIPTION
If the `linkerd buoyant dashboard` command encountered a failure opening
the default browser, it would just quit with an error.

Modify `linkerd buoyant dashboard` to catch browser open errors, and
instead print a message to the user instructing them to manually open a
browser. This is similar to `linkerd viz dashboard` behavior.

New output:
```
$ go run cli/main.go dashboard
Opening Buoyant Cloud dashboard in the default browser
Failed to open dashboard automatically
Visit https://buoyant.cloud in your browser to view the dashboard
```

Fixes #32

Signed-off-by: Andrew Seigner <siggy@buoyant.io>