### PR TITLE
Provide a link to the #buoyant-cloud Slack

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -105,6 +105,8 @@ func install(ctx context.Context, cfg *config, client k8s.Client, openURL openUR
 
 	fmt.Fprintf(cfg.stderr, "Agent manifest available at:\n%s\n\n", agentURL)
 
+	fmt.Fprint(cfg.stderr, "Need help? Message us in the #buoyant-cloud Slack channel:\nhttps://linkerd.slack.com/archives/C01QSTM20BY\n\n")
+
 	return nil
 }
 


### PR DESCRIPTION
On `linkerd-buoyant install`, print a message to stderr pointing the
user to the #buoyant-cloud Slack channel.

```
linkerd-buoyant install
...
Agent manifest available at:
https://buoyant.cloud/agent/buoyant-cloud-k8s-foo.yml

Need help? Message us in the #buoyant-cloud Slack channel:
https://linkerd.slack.com/archives/C01QSTM20BY
```

Signed-off-by: Andrew Seigner <siggy@buoyant.io>