### PR TITLE
Stop creating draft releases, fix Helm releases

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -261,7 +261,7 @@ jobs:
       with:
         tag_name: ${{ github.ref }}
         release_name: ${{ github.ref }}
-        draft: true
+        draft: false
         prerelease: false
 
   upload_release_assets:
@@ -334,24 +334,16 @@ jobs:
       run: |
         sed -i "s/0.0.0-undefined/$helm_tag/g" charts/linkerd-buoyant/Chart.yaml
 
-    - name: Configure Git
-      run: |
-        git config user.name "Helm Releaser"
-        git config user.email info@buoyant.io
-
     - name: Set up Helm
       uses: azure/setup-helm@v1
       with:
         version: v3.4.0
 
-    - name: Run chart-releaser
-      uses: helm/chart-releaser-action@v1.2.1
-      with:
-        config: charts/cr.yaml
-      env:
-        CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+    - name: Package Helm chart
+      run: |
+        bin/cr package charts/linkerd-buoyant --config charts/cr.yaml
 
-    - name: Upload Helm chart to release
+    - name: Upload Helm chart package to GitHub Release
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -360,3 +352,18 @@ jobs:
         asset_path: ./.cr-release-packages/${{ env.helm_package }}
         asset_name: ${{ env.helm_package }}
         asset_content_type: application/octet-stream
+
+    - name: Configure Git
+      run: |
+        git config user.name "Helm Releaser"
+        git config user.email info@buoyant.io
+
+    # TODO: `cr index` downloads the helm package from the GitHub Release. It
+    # attempts to unpack the first asset it sees. This only works for us because
+    # our Helm package is listed first alphabetically in the GitHub Release.
+    - name: Update Helm chart index.yaml
+      env:
+        CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      run: |
+        mkdir .cr-index
+        bin/cr index --config charts/cr.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+.cr-index
+.cr-release-packages
 .gorun
 target

--- a/bin/cr
+++ b/bin/cr
@@ -1,0 +1,52 @@
+#!/usr/bin/env sh
+
+set -eu
+
+crv=1.3.0
+bindir=$( cd "${0%/*}" && pwd ) # Change to script dir and set bin dir to this
+targetbin=$( cd "$bindir"/.. && pwd )/target/bin
+crbin=$targetbin/cr-$crv
+os=""
+arch=""
+
+if [ ! -f "$crbin" ]; then
+    case $(uname | tr '[:upper:]' '[:lower:]') in
+        darwin*)
+            os=darwin
+            case $(uname -m) in
+                x86_64) arch=amd64 ;;
+                amd64) arch=amd64 ;;
+                arm64) arch=arm64 ;;
+            esac
+            ;;
+        linux*)
+            os=linux
+            case $(uname -m) in
+                x86_64) arch=amd64 ;;
+                amd64) arch=amd64 ;;
+                arm) arch=arm64 ;;
+            esac
+            ;;
+        msys*)
+            os=windows
+            arch=amd64
+            ;;
+    esac
+
+    if [ -z "$os" ]; then
+        echo "Couldn't find a matching binary"
+        exit 126
+    fi
+    crcurl="https://github.com/helm/chart-releaser/releases/download/v$crv/chart-releaser_${crv}_${os}_${arch}.tar.gz"
+    tmp=$(mktemp -d -t cr.XXX)
+    mkdir -p "$targetbin"
+    (
+        cd "$tmp"
+        curl -Lsf -o "./cr.tar.gz" "$crcurl"
+        tar zf "./cr.tar.gz" -x "cr"
+        chmod +x "cr"
+    )
+    mv "$tmp/cr" "$crbin"
+fi
+
+"$crbin" "$@"

--- a/charts/cr.yaml
+++ b/charts/cr.yaml
@@ -1,2 +1,11 @@
+owner: BuoyantIO
+git-repo: linkerd-buoyant
+charts-repo: https://helm.buoyant.cloud
+index-path: .cr-index/index.yaml
+package-path: .cr-release-packages
+git-base-url: https://api.github.com/
+git-upload-url: https://uploads.github.com/
+push: true
+remote: origin
 release-name-template: "v{{ .Version }}"
 skip-existing: true


### PR DESCRIPTION
PR #17 introduced a Helm chart and related GitHub Actions to package and
release the chart. Unfortunately this caused new tag pushes to create
two GitHub releases, one draft release with our CLI assets, and one
published release with our Helm package.

Modify our GitHub Actions to always create a published release, rather
than a draft. Also replace our use of `chart-releaser-action` with
caling `chart-releaser` directly. `chart-releaser-action` always runs 1)
package 2) create release 3) update index, but we only want 1 and 3.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>