### PR TITLE
Bump grafana agent from v0.20.0 to v0.21.2

### DIFF
--- a/charts/linkerd-buoyant/templates/metrics-agent.yaml
+++ b/charts/linkerd-buoyant/templates/metrics-agent.yaml
@@ -332,7 +332,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: buoyant-cloud-metrics
-        image: grafana/agent:v0.20.0
+        image: grafana/agent:v0.21.2
         args:
         - -config.file=/buoyant-cloud-metrics/agent.yml
         - -config.expand-env


### PR DESCRIPTION
Tested against a live bcloud.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>