### PR TITLE
scrape link metrics

### DIFF
--- a/charts/linkerd-buoyant/templates/metrics-agent.yaml
+++ b/charts/linkerd-buoyant/templates/metrics-agent.yaml
@@ -299,9 +299,6 @@ data:
         - job_name: 'multicluster-link'
           kubernetes_sd_configs:
           - role: pod
-            selectors:
-              - role: 'pod'
-                label: 'linkerd.io/control-plane-component=linkerd-service-mirror'
           relabel_configs:
           - source_labels:
             - __meta_kubernetes_pod_container_name

--- a/charts/linkerd-buoyant/templates/metrics-agent.yaml
+++ b/charts/linkerd-buoyant/templates/metrics-agent.yaml
@@ -295,6 +295,29 @@ data:
             regex: 'dst_control_plane_ns'
           - action: labeldrop
             regex: 'workload_ns'
+
+        - job_name: 'multicluster-link'
+          kubernetes_sd_configs:
+          - role: pod
+            selectors:
+              - role: 'pod'
+                label: 'linkerd.io/control-plane-component=linkerd-service-mirror'
+          relabel_configs:
+          - source_labels:
+            - __meta_kubernetes_pod_container_name
+            - __meta_kubernetes_pod_container_port_name
+            action: keep
+            regex: ^service-mirror;admin-http$
+          - source_labels: [__meta_kubernetes_namespace]
+            action: replace
+            target_label: namespace
+
+          metric_relabel_configs:
+
+          # keep link metrics relevant to buoyant cloud
+          - source_labels: [__name__]
+            regex: ^gateway_alive|gateway_probe_latency_ms_bucket$
+            action: keep
 ---
 #
 # Metrics Agent


### PR DESCRIPTION
This PR changes the metrics agent config to scrape metrics associated with
multicluster links.



Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>