### PR TITLE
Build image from source for helm tests

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -194,6 +194,7 @@ jobs:
         file: agent/Dockerfile
         platforms: linux/amd64
         push: false
+        load: true
         tags: ghcr.io/buoyantio/linkerd-buoyant:ci-run
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -176,6 +176,19 @@ jobs:
       run: |
         kubectl create ns buoyant-cloud
 
+    - name: Cache Docker layers
+      uses: actions/cache@v2
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-
+
+    - name: Build and load agent image
+      run: |
+        docker build  -f agent/Dockerfile . -t ghcr.io/buoyantio/linkerd-buoyant:ci-run
+        kind load docker-image ghcr.io/buoyantio/linkerd-buoyant:ci-run --name=chart-testing
+
     - name: Run chart-testing (install)
       run: ct install --config charts/ct.yaml
 

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -176,6 +176,9 @@ jobs:
       run: |
         kubectl create ns buoyant-cloud
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
     - name: Cache Docker layers
       uses: actions/cache@v2
       with:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -184,9 +184,27 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-buildx-
 
-    - name: Build and load agent image
+    - name: Build agent image
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: agent/Dockerfile
+        platforms: linux/amd64
+        push: false
+        tags: ghcr.io/buoyantio/linkerd-buoyant:ci-run
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+    - name: Move cache
+      # Temp fix
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
       run: |
-        docker build  -f agent/Dockerfile . -t ghcr.io/buoyantio/linkerd-buoyant:ci-run
+        rm -rf /tmp/.buildx-cache
+        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+    - name: Load agent image
+      run: |
         kind load docker-image ghcr.io/buoyantio/linkerd-buoyant:ci-run --name=chart-testing
 
     - name: Run chart-testing (install)

--- a/charts/linkerd-buoyant/ci/dev-values.yaml
+++ b/charts/linkerd-buoyant/ci/dev-values.yaml
@@ -4,7 +4,7 @@ agentDownloadKey: fake-agent-download-key
 agentClusterName: fake-agent-cluster-name
 agent:
   apiAddress: dockerhost:8086
-  imageVersion: latest
+  imageVersion: ci-run
   insecure: true
   logLevel: debug
 metrics:

--- a/charts/linkerd-buoyant/ci/fake-values.yaml
+++ b/charts/linkerd-buoyant/ci/fake-values.yaml
@@ -3,4 +3,4 @@ agentKey: fake-agent-key
 agentDownloadKey: fake-agent-download-key
 agentClusterName: fake-agent-cluster-name
 agent:
-  imageVersion: latest
+  imageVersion: ci-run


### PR DESCRIPTION
This PR changes our GH actions logic to use agent image built from the current source rather than pull the `latest` version.

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>