### PR TITLE
Move the CLI to the new auth flow

### DIFF
--- a/agent/pkg/bcloudapi/client.go
+++ b/agent/pkg/bcloudapi/client.go
@@ -26,14 +26,14 @@ type AgentIdentifier interface {
 	Value() string
 }
 
-// AgentID identifies and agent with its ID
+// AgentID identifies an agent with its ID.
 type AgentID string
 
 func (id AgentID) Value() string {
 	return string(id)
 }
 
-// AgentName identifies and agent with its name
+// AgentName identifies an agent with its name.
 type AgentName string
 
 func (name AgentName) Value() string {

--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -35,7 +35,7 @@ failure and exit with a non-zero exit code.`,
   linkerd-buoyant check
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := k8s.New(checkCfg.kubeconfig, checkCfg.kubecontext, checkCfg.bcloudServer)
+			client, err := k8s.New(checkCfg.kubeconfig, checkCfg.kubecontext)
 			if err != nil {
 				return err
 			}

--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -10,6 +10,7 @@ type config struct {
 	kubeconfig   string
 	verbose      bool
 	bcloudServer string
+	bcloudAPI    string
 	stdout       io.Writer
 	stderr       io.Writer
 }

--- a/cli/cmd/dashboard.go
+++ b/cli/cmd/dashboard.go
@@ -6,6 +6,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// openURL allows mocking the browser.OpenURL function, so our tests do not open
+// a browser window.
+type openURL func(url string) error
+
 func newCmdDashboard(cfg *config, openURL openURL) *cobra.Command {
 	return &cobra.Command{
 		Use:   "dashboard [flags]",

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -116,7 +116,7 @@ func install(ctx context.Context, cfg *installCfg, client k8s.Client, apiClient 
 
 	manifest, err := apiClient.GetAgentManifest(ctx, identifier)
 	if err != nil {
-		return fmt.Errorf("failed to retrieve agent manifest from bcloud server for agent identifier %T %s", identifier, identifier.Value())
+		return fmt.Errorf("failed to retrieve agent manifest from bcloud server for agent identifier %T %s: %w", identifier, identifier.Value(), err)
 	}
 
 	// output the YAML manifest, this is the only thing that outputs to stdout

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -186,8 +186,8 @@ func TestInstallError(t *testing.T) {
 		agentName: "fake-agent-name",
 	}
 
-	expectedError := errors.New("failed to retrieve agent manifest from bcloud server for agent identifier bcloudapi.AgentName fake-agent-name")
 	apiError := errors.New("problem with API")
+	expectedError := fmt.Errorf("failed to retrieve agent manifest from bcloud server for agent identifier bcloudapi.AgentName fake-agent-name: %w", apiError)
 	client := &k8s.MockClient{}
 	apiClient := &MockClient{Err: apiError}
 	err := install(context.TODO(), cfg, client, apiClient)

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -3,213 +3,195 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"reflect"
-	"strings"
 	"testing"
 
+	"github.com/buoyantio/linkerd-buoyant/agent/pkg/bcloudapi"
 	"github.com/buoyantio/linkerd-buoyant/cli/pkg/k8s"
-	"github.com/buoyantio/linkerd-buoyant/cli/pkg/version"
+	"google.golang.org/grpc/credentials"
 )
 
+type MockClient struct {
+	Identifier       bcloudapi.AgentIdentifier
+	ManifestToReturn string
+	Err              error
+}
+
+func (mc *MockClient) GetAgentManifest(ctx context.Context, identifier bcloudapi.AgentIdentifier) (string, error) {
+	mc.Identifier = identifier
+	if mc.Err != nil {
+		return "", mc.Err
+	}
+	return mc.ManifestToReturn, nil
+}
+
+func (mc *MockClient) RegisterAgent(ctx context.Context, agentName string) (*bcloudapi.AgentInfo, error) {
+	return nil, nil
+}
+
+func (mc *MockClient) Credentials(ctx context.Context, agentID string) credentials.PerRPCCredentials {
+	return nil
+}
+
+const fakeAgentName = "fake-agent-name"
+const fakeAgentID = "fake-agent-id"
+const fakeYaml = "fake-yaml"
+
 func TestInstallNewAgent(t *testing.T) {
-	totalRequests := 0
-	connectRequests := 0
-	redirectRequests := 0
-	agentUID := "'"
-	ts := httptest.NewServer(http.HandlerFunc(
-		func(w http.ResponseWriter, r *http.Request) {
-			totalRequests++
-			switch r.URL.Path {
-			case "/connect-agent":
-				connectRequests++
-				agentUID = r.URL.Query().Get(version.LinkerdBuoyant)
-				if connectRequests == 1 {
-					w.WriteHeader(http.StatusAccepted)
-					return
-				}
-
-				if connectRequests == 2 {
-					w.WriteHeader(http.StatusBadGateway)
-					return
-				}
-
-				http.Redirect(w, r, "/agent-yaml-redirect", http.StatusPermanentRedirect)
-			case "/agent-yaml-redirect":
-				redirectRequests++
-				w.Header().Set("Content-Type", "text/yaml")
-				w.Write([]byte("fake-yaml"))
-			}
-		},
-	))
-	defer ts.Close()
-
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
-	cfg := &config{
-		stdout:       stdout,
-		stderr:       stderr,
-		bcloudServer: ts.URL,
+	cfg := &installCfg{
+		config: &config{
+			stdout: stdout,
+			stderr: stderr,
+		},
+		agentName: fakeAgentName,
 	}
 
 	client := &k8s.MockClient{}
-	err := install(context.TODO(), cfg, client, mockOpenURL)
+	apiClient := &MockClient{ManifestToReturn: fakeYaml}
+
+	err := install(context.TODO(), cfg, client, apiClient)
 	if err != nil {
 		t.Error(err)
 	}
 
-	if stdout.String() != "fake-yaml\n" {
-		t.Errorf("Expected: [fake-yaml], Got: [%s]", stdout.String())
-	}
-	expBrowserURL := fmt.Sprintf("%s/connect-cluster?linkerd-buoyant=%s", ts.URL, agentUID)
-	if !strings.Contains(stderr.String(), expBrowserURL) {
-		t.Errorf("Expected stderr to contain [%s], Got: [%s]", expBrowserURL, stderr.String())
-	}
-	if totalRequests != 4 {
-		t.Errorf("Expected 4 total requests, called %d times", totalRequests)
-	}
-	if connectRequests != 3 {
-		t.Errorf("Expected 3 /connect-agent requests, called %d times", connectRequests)
-	}
-	if redirectRequests != 1 {
-		t.Errorf("Expected 1 /agent-yaml-redirect request, called %d times", redirectRequests)
-	}
-}
-
-func TestInstalWithPollingFailures(t *testing.T) {
-	totalRequests := 0
-	connectRequests := 0
-	agentUID := "'"
-	ts := httptest.NewServer(http.HandlerFunc(
-		func(w http.ResponseWriter, r *http.Request) {
-			totalRequests++
-			switch r.URL.Path {
-			case "/connect-agent":
-				agentUID = r.URL.Query().Get(version.LinkerdBuoyant)
-				connectRequests++
-				w.WriteHeader(http.StatusBadGateway)
-			}
-		},
-	))
-	defer ts.Close()
-
-	stdout := &bytes.Buffer{}
-	stderr := &bytes.Buffer{}
-	cfg := &config{
-		stdout:       stdout,
-		stderr:       stderr,
-		bcloudServer: ts.URL,
+	if stdout.String() != fmt.Sprintf("%s\n", fakeYaml) {
+		t.Errorf("Expected: [%s], Got: [%s]", fakeYaml, stdout.String())
 	}
 
-	client := &k8s.MockClient{}
-	err := install(context.TODO(), cfg, client, mockOpenURL)
-	expErr := fmt.Errorf("setup failed, unexpected HTTP status code 502 for URL %s/connect-agent?linkerd-buoyant=%s", ts.URL, agentUID)
-	if !reflect.DeepEqual(err, expErr) {
-		t.Errorf("Expected error: %s, Got: %s", expErr, err)
+	name, ok := apiClient.Identifier.(bcloudapi.AgentName)
+	if !ok {
+		t.Fatalf("Expected to call api with AgentName, called with: %+v", apiClient.Identifier)
 	}
-
-	if totalRequests != maxPollingRetries {
-		t.Errorf("Expected %d total requests, called %d times", maxPollingRetries, totalRequests)
-	}
-	if connectRequests != maxPollingRetries {
-		t.Errorf("Expected %d /connect-agent requests, called %d times", maxPollingRetries, connectRequests)
+	if name.Value() != fakeAgentName {
+		t.Fatalf("Expected name identifier to be %s, got: %s", fakeAgentName, name.Value())
 	}
 }
 
 func TestInstallExistingAgent(t *testing.T) {
-	totalRequests := 0
-	connectRequests := 0
-	ts := httptest.NewServer(http.HandlerFunc(
-		func(w http.ResponseWriter, r *http.Request) {
-			totalRequests++
-			if r.URL.Path == "/connect-agent-url" {
-				connectRequests++
-				w.Header().Set("Content-Type", "text/yaml")
-				w.Write([]byte("fake-yaml"))
-			}
-		},
-	))
-	defer ts.Close()
+	t.Run("gets manifest with name", func(t *testing.T) {
+		stdout := &bytes.Buffer{}
+		stderr := &bytes.Buffer{}
+		cfg := &installCfg{
+			config: &config{
+				stdout: stdout,
+				stderr: stderr,
+			},
+		}
 
-	stdout := &bytes.Buffer{}
-	stderr := &bytes.Buffer{}
-	cfg := &config{
-		stdout:       stdout,
-		stderr:       stderr,
-		bcloudServer: ts.URL,
-	}
+		client := &k8s.MockClient{
+			MockAgent: &k8s.Agent{
+				Name:    fakeAgentName,
+				Version: "version",
+			},
+		}
+		apiClient := &MockClient{ManifestToReturn: fakeYaml}
 
-	client := &k8s.MockClient{
-		MockAgent: &k8s.Agent{
-			Name:    "name",
-			URL:     ts.URL + "/connect-agent-url",
-			Version: "version",
-		},
-	}
-	err := install(context.TODO(), cfg, client, mockOpenURL)
-	if err != nil {
-		t.Error(err)
-	}
+		err := install(context.TODO(), cfg, client, apiClient)
+		if err != nil {
+			t.Error(err)
+		}
+		if stdout.String() != fmt.Sprintf("%s\n", fakeYaml) {
+			t.Errorf("Expected: [%s], Got: [%s]", fakeYaml, stdout.String())
+		}
 
-	if stdout.String() != "fake-yaml\n" {
-		t.Errorf("Expected: [fake-yaml], Got: [%s]", stdout.String())
-	}
-	if totalRequests != 1 {
-		t.Errorf("Expected 1 total request, called %d times", totalRequests)
-	}
-	if connectRequests != 1 {
-		t.Errorf("Expected 1 /connect-agent-url request, called %d times", connectRequests)
-	}
+		name, ok := apiClient.Identifier.(bcloudapi.AgentName)
+		if !ok {
+			t.Fatalf("Expected to call api with AgentName, called with: %+v", apiClient.Identifier)
+		}
+		if name.Value() != fakeAgentName {
+			t.Fatalf("Expected name identifier to be %s, got: %s", fakeAgentName, name.Value())
+		}
+	})
+
+	t.Run("gets manifest with Id", func(t *testing.T) {
+		stdout := &bytes.Buffer{}
+		stderr := &bytes.Buffer{}
+		cfg := &installCfg{
+			config: &config{
+				stdout: stdout,
+				stderr: stderr,
+			},
+		}
+
+		client := &k8s.MockClient{
+			MockAgent: &k8s.Agent{
+				Id:      fakeAgentID,
+				Version: "version",
+			},
+		}
+		apiClient := &MockClient{ManifestToReturn: fakeYaml}
+
+		err := install(context.TODO(), cfg, client, apiClient)
+		if err != nil {
+			t.Error(err)
+		}
+		if stdout.String() != fmt.Sprintf("%s\n", fakeYaml) {
+			t.Errorf("Expected: [%s], Got: [%s]", fakeYaml, stdout.String())
+		}
+
+		id, ok := apiClient.Identifier.(bcloudapi.AgentID)
+		if !ok {
+			t.Fatalf("Expected to call api with AgentID, called with: %+v", apiClient.Identifier)
+		}
+		if id.Value() != fakeAgentID {
+			t.Fatalf("Expected name identifier to be %s, got: %s", fakeAgentID, id.Value())
+		}
+	})
+
+	t.Run("invalid agent data", func(t *testing.T) {
+		stdout := &bytes.Buffer{}
+		stderr := &bytes.Buffer{}
+		cfg := &installCfg{
+			config: &config{
+				stdout: stdout,
+				stderr: stderr,
+			},
+		}
+
+		client := &k8s.MockClient{
+			MockAgent: &k8s.Agent{
+				Version: "version",
+			},
+		}
+		apiClient := &MockClient{ManifestToReturn: fakeYaml}
+
+		expectedError := errors.New("could not find valid agent installation")
+		err := install(context.TODO(), cfg, client, apiClient)
+
+		if !reflect.DeepEqual(err, expectedError) {
+			t.Errorf("Expected error: %s, Got: %s", expectedError, err)
+		}
+
+		expectedStdErr := `Could not find valid agent installation on cluster. To install agent run:
+linkerd buoyant install --agent-name=my-new-agent | kubectl apply -f -
+`
+		if expectedStdErr != stderr.String() {
+			t.Errorf("Expected:\n%s\nGot:\n%s", expectedStdErr, stderr.String())
+		}
+	})
 }
 
-func TestInstallBadStatus(t *testing.T) {
-	totalRequests := 0
-	connectRequests := 0
-	ts := httptest.NewServer(http.HandlerFunc(
-		func(w http.ResponseWriter, r *http.Request) {
-			totalRequests++
-			if r.URL.Path == "/connect-agent-url" {
-				connectRequests++
-				w.WriteHeader(http.StatusInternalServerError)
-			}
-		},
-	))
-	defer ts.Close()
-
+func TestInstallError(t *testing.T) {
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
-	cfg := &config{
-		stdout:       stdout,
-		stderr:       stderr,
-		bcloudServer: ts.URL,
-	}
-
-	client := &k8s.MockClient{
-		MockAgent: &k8s.Agent{
-			Name:    "name",
-			URL:     ts.URL + "/connect-agent-url",
-			Version: "version",
+	cfg := &installCfg{
+		config: &config{
+			stdout: stdout,
+			stderr: stderr,
 		},
-	}
-	expErr := fmt.Errorf("failed to retrieve agent manifest from %s", client.MockAgent.URL)
-	err := install(context.TODO(), cfg, client, mockOpenURL)
-	if !reflect.DeepEqual(err, expErr) {
-		t.Errorf("Expected error: %s, Got: %s", expErr, err)
+		agentName: "fake-agent-name",
 	}
 
-	if stdout.String() != "" {
-		t.Errorf("Expected: no stdout, Got: [%s]", stdout.String())
+	expectedError := errors.New("failed to retrieve agent manifest from bcloud server for agent identifier bcloudapi.AgentName fake-agent-name")
+	apiError := errors.New("problem with API")
+	client := &k8s.MockClient{}
+	apiClient := &MockClient{Err: apiError}
+	err := install(context.TODO(), cfg, client, apiClient)
+	if !reflect.DeepEqual(err, expectedError) {
+		t.Errorf("Expected error: %s, Got: %s", expectedError, err)
 	}
-	if totalRequests != 1 {
-		t.Errorf("Expected 1 total request, called %d times", totalRequests)
-	}
-	if connectRequests != 1 {
-		t.Errorf("Expected 1 /connect-agent-url request, called %d times", connectRequests)
-	}
-}
-
-func mockOpenURL(string) error {
-	return nil
 }

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -49,7 +49,7 @@ upgrade, and delete functionality.`,
 
 	// hidden flags
 	root.PersistentFlags().StringVar(&cfg.bcloudServer, "bcloud-server", "https://buoyant.cloud", "Buoyant Cloud server to retrieve manifests from (for testing)")
-	root.PersistentFlags().StringVar(&cfg.bcloudAPI, "bcloud-api", "https://api.buoyant.cloud", "Buoyant Cloud API to retrieve manifests from (for testing)")
+	root.PersistentFlags().StringVar(&cfg.bcloudAPI, "bcloud-api", "api.buoyant.cloud:443", "Buoyant Cloud API to retrieve manifests from (for testing)")
 
 	root.PersistentFlags().MarkHidden("bcloud-server")
 	root.PersistentFlags().MarkHidden("bcloud-api")

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -49,7 +49,10 @@ upgrade, and delete functionality.`,
 
 	// hidden flags
 	root.PersistentFlags().StringVar(&cfg.bcloudServer, "bcloud-server", "https://buoyant.cloud", "Buoyant Cloud server to retrieve manifests from (for testing)")
+	root.PersistentFlags().StringVar(&cfg.bcloudAPI, "bcloud-api", "https://api.buoyant.cloud", "Buoyant Cloud API retrieve manifests from (for testing)")
+
 	root.PersistentFlags().MarkHidden("bcloud-server")
+	root.PersistentFlags().MarkHidden("bcloud-api")
 
 	// hidden and unused flags, to satisfy linkerd extension interface
 	var apiAddr, l5dVersion string

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -49,7 +49,7 @@ upgrade, and delete functionality.`,
 
 	// hidden flags
 	root.PersistentFlags().StringVar(&cfg.bcloudServer, "bcloud-server", "https://buoyant.cloud", "Buoyant Cloud server to retrieve manifests from (for testing)")
-	root.PersistentFlags().StringVar(&cfg.bcloudAPI, "bcloud-api", "https://api.buoyant.cloud", "Buoyant Cloud API retrieve manifests from (for testing)")
+	root.PersistentFlags().StringVar(&cfg.bcloudAPI, "bcloud-api", "https://api.buoyant.cloud", "Buoyant Cloud API to retrieve manifests from (for testing)")
 
 	root.PersistentFlags().MarkHidden("bcloud-server")
 	root.PersistentFlags().MarkHidden("bcloud-api")

--- a/cli/cmd/uninstall.go
+++ b/cli/cmd/uninstall.go
@@ -62,7 +62,7 @@ func uninstall(ctx context.Context, cfg *config, client k8s.Client) error {
 
 	// if agent is present, output its name and URL for posterity
 	if agent != nil {
-		fmt.Fprintf(cfg.stderr, "Agent manifest will remain available at:\n%s\n\n", agent.URL)
+		fmt.Fprintf(cfg.stderr, "Agent manifest will remain available via :\nlinkerd buoyant install --agent-name=%s\n\n", agent.Name)
 	}
 
 	return nil

--- a/cli/cmd/uninstall.go
+++ b/cli/cmd/uninstall.go
@@ -24,7 +24,7 @@ Agent.`,
   # Unnstall from a specific cluster
   linkerd buoyant --context test-cluster uninstall | kubectl delete --context test-cluster -f -`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := k8s.New(cfg.kubeconfig, cfg.kubecontext, cfg.bcloudServer)
+			client, err := k8s.New(cfg.kubeconfig, cfg.kubecontext)
 			if err != nil {
 				return err
 			}
@@ -60,7 +60,7 @@ func uninstall(ctx context.Context, cfg *config, client k8s.Client) error {
 		fmt.Fprintf(cfg.stderr, "\n")
 	}
 
-	// if agent is present, output its name and URL for posterity
+	// if agent is present, output its name and command for posterity
 	if agent != nil {
 		fmt.Fprintf(cfg.stderr, "Agent manifest will remain available via :\nlinkerd buoyant install --agent-name=%s\n\n", agent.Name)
 	}

--- a/cli/cmd/uninstall.go
+++ b/cli/cmd/uninstall.go
@@ -62,7 +62,7 @@ func uninstall(ctx context.Context, cfg *config, client k8s.Client) error {
 
 	// if agent is present, output its name and command for posterity
 	if agent != nil {
-		fmt.Fprintf(cfg.stderr, "Agent manifest will remain available via :\nlinkerd buoyant install --agent-name=%s\n\n", agent.Name)
+		fmt.Fprintf(cfg.stderr, "Agent manifest will remain available via:\nlinkerd buoyant install --agent-name=%s\n\n", agent.Name)
 	}
 
 	return nil

--- a/cli/cmd/uninstall_test.go
+++ b/cli/cmd/uninstall_test.go
@@ -20,7 +20,7 @@ func TestUninstall(t *testing.T) {
 	}
 
 	client := &k8s.MockClient{
-		MockAgent:     &k8s.Agent{URL: "/fake-url"},
+		MockAgent:     &k8s.Agent{Name: "/fake-url"},
 		MockResources: []string{"resource-1", "resource-2", "resource-3"},
 	}
 	err := uninstall(context.TODO(), cfg, client)

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -27,7 +27,7 @@ func newCmdVersion(cfg *config) *cobra.Command {
 				return versionCmd(cmd.Context(), versionCfg, nil)
 			}
 
-			client, err := k8s.New(cfg.kubeconfig, cfg.kubecontext, cfg.bcloudServer)
+			client, err := k8s.New(cfg.kubeconfig, cfg.kubecontext)
 			if err != nil {
 				return err
 			}

--- a/cli/pkg/healthcheck/healthcheck.go
+++ b/cli/pkg/healthcheck/healthcheck.go
@@ -133,11 +133,11 @@ func (hc *HealthChecker) globalChecks() []healthcheck.Checker {
 		*healthcheck.NewChecker("buoyant-cloud-id Secret exists").
 			Fatal().
 			WithCheck(func(ctx context.Context) error {
-				secret, err := hc.k8s.Secret(ctx)
+				cm, err := hc.k8s.ConfigMap(ctx)
 				if err != nil {
 					return err
 				}
-				return checkLabel(secret.GetLabels(), k8s.PartOfKey, k8s.PartOfVal)
+				return checkLabel(cm.GetLabels(), k8s.PartOfKey, k8s.PartOfVal)
 			}),
 	}
 }

--- a/cli/pkg/healthcheck/healthcheck.go
+++ b/cli/pkg/healthcheck/healthcheck.go
@@ -103,6 +103,26 @@ func (hc *HealthChecker) globalChecks() []healthcheck.Checker {
 				}
 				return checkLabel(hc.ns.GetLabels(), k8s.PartOfKey, k8s.PartOfVal)
 			}),
+		*healthcheck.NewChecker("agent-metadata ConfigMap exists").
+			Fatal().
+			WithCheck(func(ctx context.Context) error {
+				cm, err := hc.k8s.ConfigMap(ctx)
+				if err != nil {
+					return err
+				}
+
+				return checkLabel(cm.GetLabels(), k8s.PartOfKey, k8s.PartOfVal)
+			}),
+		*healthcheck.NewChecker("buoyant-cloud-org-credentials Secret exists").
+			Fatal().
+			WithCheck(func(ctx context.Context) error {
+				secret, err := hc.k8s.Secret(ctx)
+				if err != nil {
+					return err
+				}
+
+				return checkLabel(secret.GetLabels(), k8s.PartOfKey, k8s.PartOfVal)
+			}),
 		*healthcheck.NewChecker("buoyant-cloud-agent ClusterRole exists").
 			Fatal().
 			WithCheck(func(ctx context.Context) error {
@@ -129,26 +149,6 @@ func (hc *HealthChecker) globalChecks() []healthcheck.Checker {
 					return err
 				}
 				return checkLabel(sa.GetLabels(), k8s.PartOfKey, k8s.PartOfVal)
-			}),
-		*healthcheck.NewChecker("agent-metadata ConfigMap exists").
-			Fatal().
-			WithCheck(func(ctx context.Context) error {
-				cm, err := hc.k8s.ConfigMap(ctx)
-				if err != nil {
-					return err
-				}
-
-				return checkLabel(cm.GetLabels(), k8s.PartOfKey, k8s.PartOfVal)
-			}),
-		*healthcheck.NewChecker("buoyant-cloud-org-credentials Secret exists").
-			Fatal().
-			WithCheck(func(ctx context.Context) error {
-				secret, err := hc.k8s.Secret(ctx)
-				if err != nil {
-					return err
-				}
-
-				return checkLabel(secret.GetLabels(), k8s.PartOfKey, k8s.PartOfVal)
 			}),
 	}
 }

--- a/cli/pkg/healthcheck/healthcheck.go
+++ b/cli/pkg/healthcheck/healthcheck.go
@@ -130,14 +130,25 @@ func (hc *HealthChecker) globalChecks() []healthcheck.Checker {
 				}
 				return checkLabel(sa.GetLabels(), k8s.PartOfKey, k8s.PartOfVal)
 			}),
-		*healthcheck.NewChecker("buoyant-cloud-id Secret exists").
+		*healthcheck.NewChecker("agent-metadata ConfigMap exists").
 			Fatal().
 			WithCheck(func(ctx context.Context) error {
 				cm, err := hc.k8s.ConfigMap(ctx)
 				if err != nil {
 					return err
 				}
+
 				return checkLabel(cm.GetLabels(), k8s.PartOfKey, k8s.PartOfVal)
+			}),
+		*healthcheck.NewChecker("buoyant-cloud-org-credentials Secret exists").
+			Fatal().
+			WithCheck(func(ctx context.Context) error {
+				secret, err := hc.k8s.Secret(ctx)
+				if err != nil {
+					return err
+				}
+
+				return checkLabel(secret.GetLabels(), k8s.PartOfKey, k8s.PartOfVal)
 			}),
 	}
 }

--- a/cli/pkg/healthcheck/healthcheck_test.go
+++ b/cli/pkg/healthcheck/healthcheck_test.go
@@ -114,6 +114,9 @@ Status check results are ×
 						MockConfigMap: &v1.ConfigMap{
 							ObjectMeta: objMeta,
 						},
+						MockSecret: &v1.Secret{
+							ObjectMeta: objMeta,
+						},
 						MockServiceAccount: &v1.ServiceAccount{
 							ObjectMeta: objMeta,
 						},
@@ -157,7 +160,8 @@ Status check results are ×
 √ buoyant-cloud-agent ClusterRole exists
 √ buoyant-cloud-agent ClusterRoleBinding exists
 √ buoyant-cloud-agent ServiceAccount exists
-√ buoyant-cloud-id Secret exists
+√ agent-metadata ConfigMap exists
+√ buoyant-cloud-org-credentials Secret exists
 √ buoyant-cloud-agent Deployment exists
 √ buoyant-cloud-agent Deployment is running
 √ buoyant-cloud-agent Deployment is injected

--- a/cli/pkg/healthcheck/healthcheck_test.go
+++ b/cli/pkg/healthcheck/healthcheck_test.go
@@ -111,7 +111,7 @@ Status check results are ×
 						MockClusterRoleBinding: &rbacv1.ClusterRoleBinding{
 							ObjectMeta: objMeta,
 						},
-						MockSecret: &v1.Secret{
+						MockConfigMap: &v1.ConfigMap{
 							ObjectMeta: objMeta,
 						},
 						MockServiceAccount: &v1.ServiceAccount{

--- a/cli/pkg/healthcheck/healthcheck_test.go
+++ b/cli/pkg/healthcheck/healthcheck_test.go
@@ -157,11 +157,11 @@ Status check results are ×
 √ linkerd-buoyant cli is up-to-date
 √ buoyant-cloud Namespace exists
 √ buoyant-cloud Namespace has correct labels
+√ agent-metadata ConfigMap exists
+√ buoyant-cloud-org-credentials Secret exists
 √ buoyant-cloud-agent ClusterRole exists
 √ buoyant-cloud-agent ClusterRoleBinding exists
 √ buoyant-cloud-agent ServiceAccount exists
-√ agent-metadata ConfigMap exists
-√ buoyant-cloud-org-credentials Secret exists
 √ buoyant-cloud-agent Deployment exists
 √ buoyant-cloud-agent Deployment is running
 √ buoyant-cloud-agent Deployment is injected

--- a/cli/pkg/k8s/agent.go
+++ b/cli/pkg/k8s/agent.go
@@ -15,7 +15,8 @@ const (
 	// VersionLabel is the label key for the agent's version
 	VersionLabel = "app.kubernetes.io/version"
 
-	agentMetadataMap = "agent-metadata"
+	agentMetadataMap     = "agent-metadata"
+	orgCredentialsSecret = "buoyant-cloud-org-credentials"
 )
 
 // Agent represents the Buoyant Cloud agent. Any of these fields may not be

--- a/cli/pkg/k8s/agent.go
+++ b/cli/pkg/k8s/agent.go
@@ -2,8 +2,8 @@ package k8s
 
 import (
 	"context"
-	"fmt"
 
+	agentk8s "github.com/buoyantio/linkerd-buoyant/agent/pkg/k8s"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
@@ -15,31 +15,28 @@ const (
 	// VersionLabel is the label key for the agent's version
 	VersionLabel = "app.kubernetes.io/version"
 
-	agentSecret = "buoyant-cloud-id"
+	agentMetadataMap = "agent-metadata"
 )
 
 // Agent represents the Buoyant Cloud agent. Any of these fields may not be
 // present, depending on which resources are already on the cluster.
 type Agent struct {
 	Name    string
+	Id      string
 	Version string
-	URL     string
 }
 
 func (c *client) Agent(ctx context.Context) (*Agent, error) {
-	var name, version, url string
+	var name, id, version string
 
-	secret, err := c.Secret(ctx)
+	cm, err := c.ConfigMap(ctx)
 	if err == nil {
-		name = string(secret.Data["name"])
-		url = fmt.Sprintf(
-			"%s/agent/buoyant-cloud-k8s-%s-%s-%s.yml",
-			c.bcloudServer, secret.Data["name"], secret.Data["id"], secret.Data["downloadKey"],
-		)
+		name = cm.Data[agentk8s.AgentNameKey]
+		id = cm.Data[agentk8s.AgentIDKey]
 	} else if !kerrors.IsNotFound(err) {
 		return nil, err
 	} else {
-		// secret not found, we can't identify the agent
+		// config map not found, we can't identify the agent
 		return nil, nil
 	}
 
@@ -51,8 +48,8 @@ func (c *client) Agent(ctx context.Context) (*Agent, error) {
 	}
 
 	return &Agent{
-		name,
-		version,
-		url,
+		Name:    name,
+		Id:      id,
+		Version: version,
 	}, nil
 }

--- a/cli/pkg/k8s/agent_test.go
+++ b/cli/pkg/k8s/agent_test.go
@@ -76,7 +76,7 @@ func TestAgent(t *testing.T) {
 		t.Run(tc.testName, func(t *testing.T) {
 			ctx := context.TODO()
 			fakeCS := fake.NewSimpleClientset(tc.objs...)
-			client := client{fakeCS, ""}
+			client := client{fakeCS}
 
 			agent, err := client.Agent(ctx)
 			if !errors.Is(err, tc.expErr) {

--- a/cli/pkg/k8s/agent_test.go
+++ b/cli/pkg/k8s/agent_test.go
@@ -30,30 +30,28 @@ func TestAgent(t *testing.T) {
 		{
 			"secret found",
 			[]runtime.Object{
-				&v1.Secret{
-					ObjectMeta: metav1.ObjectMeta{Name: agentSecret, Namespace: k8s.AgentNamespace},
-					Data: map[string][]byte{
-						"name":        []byte("fake-name"),
-						"id":          []byte("fake-id"),
-						"downloadKey": []byte("fake-downloadKey"),
+				&v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: agentMetadataMap, Namespace: k8s.AgentNamespace},
+					Data: map[string]string{
+						k8s.AgentNameKey: "fake-name",
+						k8s.AgentIDKey:   "fake-id",
 					},
 				},
 			},
 			nil,
 			&Agent{
 				Name: "fake-name",
-				URL:  "/agent/buoyant-cloud-k8s-fake-name-fake-id-fake-downloadKey.yml",
+				Id:   "fake-id",
 			},
 		},
 		{
 			"secret and deployment found",
 			[]runtime.Object{
-				&v1.Secret{
-					ObjectMeta: metav1.ObjectMeta{Name: agentSecret, Namespace: k8s.AgentNamespace},
-					Data: map[string][]byte{
-						"name":        []byte("fake-name"),
-						"id":          []byte("fake-id"),
-						"downloadKey": []byte("fake-downloadKey"),
+				&v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: agentMetadataMap, Namespace: k8s.AgentNamespace},
+					Data: map[string]string{
+						k8s.AgentNameKey: "fake-name",
+						k8s.AgentIDKey:   "fake-id",
 					},
 				},
 				&appsv1.Deployment{
@@ -67,7 +65,7 @@ func TestAgent(t *testing.T) {
 			nil,
 			&Agent{
 				Name:    "fake-name",
-				URL:     "/agent/buoyant-cloud-k8s-fake-name-fake-id-fake-downloadKey.yml",
+				Id:      "fake-id",
 				Version: "fake-version",
 			},
 		},

--- a/cli/pkg/k8s/client.go
+++ b/cli/pkg/k8s/client.go
@@ -21,8 +21,8 @@ type (
 		ClusterRole(ctx context.Context) (*rbacv1.ClusterRole, error)
 		// ClusterRoleBinding retrieves the buoyant-cloud-agent CRB.
 		ClusterRoleBinding(ctx context.Context) (*rbacv1.ClusterRoleBinding, error)
-		// Secret retrieves the buoyant-cloud-id Secret.
-		Secret(ctx context.Context) (*v1.Secret, error)
+		// ConfigMap retrieves the agent-metadata ConfigMap.
+		ConfigMap(ctx context.Context) (*v1.ConfigMap, error)
 		// ServiceAccount retrieves the buoyant-cloud-agent ServiceAccount.
 		ServiceAccount(ctx context.Context) (*v1.ServiceAccount, error)
 		// DaemonSet retrieves a DaemonSet by name in the buoyant-cloud namespace.
@@ -96,11 +96,11 @@ func (c *client) ClusterRoleBinding(ctx context.Context) (*rbacv1.ClusterRoleBin
 		Get(ctx, AgentName, metav1.GetOptions{})
 }
 
-func (c *client) Secret(ctx context.Context) (*v1.Secret, error) {
+func (c *client) ConfigMap(ctx context.Context) (*v1.ConfigMap, error) {
 	return c.
 		CoreV1().
-		Secrets(k8s.AgentNamespace).
-		Get(ctx, agentSecret, metav1.GetOptions{})
+		ConfigMaps(k8s.AgentNamespace).
+		Get(ctx, agentMetadataMap, metav1.GetOptions{})
 }
 
 func (c *client) ServiceAccount(ctx context.Context) (*v1.ServiceAccount, error) {

--- a/cli/pkg/k8s/client.go
+++ b/cli/pkg/k8s/client.go
@@ -23,6 +23,8 @@ type (
 		ClusterRoleBinding(ctx context.Context) (*rbacv1.ClusterRoleBinding, error)
 		// ConfigMap retrieves the agent-metadata ConfigMap.
 		ConfigMap(ctx context.Context) (*v1.ConfigMap, error)
+		// Secret retrieves the buoyant-cloud-org-credentials Secret.
+		Secret(ctx context.Context) (*v1.Secret, error)
 		// ServiceAccount retrieves the buoyant-cloud-agent ServiceAccount.
 		ServiceAccount(ctx context.Context) (*v1.ServiceAccount, error)
 		// DaemonSet retrieves a DaemonSet by name in the buoyant-cloud namespace.
@@ -101,6 +103,13 @@ func (c *client) ConfigMap(ctx context.Context) (*v1.ConfigMap, error) {
 		CoreV1().
 		ConfigMaps(k8s.AgentNamespace).
 		Get(ctx, agentMetadataMap, metav1.GetOptions{})
+}
+
+func (c *client) Secret(ctx context.Context) (*v1.Secret, error) {
+	return c.
+		CoreV1().
+		Secrets(k8s.AgentNamespace).
+		Get(ctx, orgCredentialsSecret, metav1.GetOptions{})
 }
 
 func (c *client) ServiceAccount(ctx context.Context) (*v1.ServiceAccount, error) {

--- a/cli/pkg/k8s/client.go
+++ b/cli/pkg/k8s/client.go
@@ -51,12 +51,11 @@ type (
 	// client is the internal struct satisfying the Client interface
 	client struct {
 		kubernetes.Interface
-		bcloudServer string
 	}
 )
 
 // New takes a kubeconfig and kubecontext and returns an initialized Client.
-func New(kubeconfig, kubecontext, bcloudServer string) (Client, error) {
+func New(kubeconfig, kubecontext string) (Client, error) {
 	rules := clientcmd.NewDefaultClientConfigLoadingRules()
 	rules.ExplicitPath = kubeconfig
 
@@ -74,7 +73,7 @@ func New(kubeconfig, kubecontext, bcloudServer string) (Client, error) {
 		return nil, err
 	}
 
-	return &client{clientset, bcloudServer}, nil
+	return &client{clientset}, nil
 }
 
 func (c *client) Namespace(ctx context.Context) (*v1.Namespace, error) {

--- a/cli/pkg/k8s/client_test.go
+++ b/cli/pkg/k8s/client_test.go
@@ -40,7 +40,7 @@ func TestNamespace(t *testing.T) {
 		t.Run(tc.testName, func(t *testing.T) {
 			ctx := context.TODO()
 			fakeCS := fake.NewSimpleClientset(tc.objs...)
-			client := client{fakeCS, ""}
+			client := client{fakeCS}
 
 			ns, err := client.Namespace(ctx)
 			if !reflect.DeepEqual(err, tc.expErr) {

--- a/cli/pkg/k8s/mock_client.go
+++ b/cli/pkg/k8s/mock_client.go
@@ -13,7 +13,7 @@ type MockClient struct {
 	MockNamespace          *v1.Namespace
 	MockClusterRole        *rbacv1.ClusterRole
 	MockClusterRoleBinding *rbacv1.ClusterRoleBinding
-	MockSecret             *v1.Secret
+	MockConfigMap          *v1.ConfigMap
 	MockServiceAccount     *v1.ServiceAccount
 	MockDaemonSet          *appsv1.DaemonSet
 	MockDeployment         *appsv1.Deployment
@@ -38,9 +38,9 @@ func (m *MockClient) ClusterRoleBinding(ctx context.Context) (*rbacv1.ClusterRol
 	return m.MockClusterRoleBinding, nil
 }
 
-// Secret returns a mock Secret object.
-func (m *MockClient) Secret(ctx context.Context) (*v1.Secret, error) {
-	return m.MockSecret, nil
+// Secret returns a mock ConfigMap object.
+func (m *MockClient) ConfigMap(ctx context.Context) (*v1.ConfigMap, error) {
+	return m.MockConfigMap, nil
 }
 
 // ServiceAccount returns a mock ServiceAccount object.

--- a/cli/pkg/k8s/mock_client.go
+++ b/cli/pkg/k8s/mock_client.go
@@ -14,6 +14,7 @@ type MockClient struct {
 	MockClusterRole        *rbacv1.ClusterRole
 	MockClusterRoleBinding *rbacv1.ClusterRoleBinding
 	MockConfigMap          *v1.ConfigMap
+	MockSecret             *v1.Secret
 	MockServiceAccount     *v1.ServiceAccount
 	MockDaemonSet          *appsv1.DaemonSet
 	MockDeployment         *appsv1.Deployment
@@ -38,9 +39,14 @@ func (m *MockClient) ClusterRoleBinding(ctx context.Context) (*rbacv1.ClusterRol
 	return m.MockClusterRoleBinding, nil
 }
 
-// Secret returns a mock ConfigMap object.
+// ConfigMap returns a mock ConfigMap object.
 func (m *MockClient) ConfigMap(ctx context.Context) (*v1.ConfigMap, error) {
 	return m.MockConfigMap, nil
+}
+
+// Secret returns a mock Secret object.
+func (m *MockClient) Secret(ctx context.Context) (*v1.Secret, error) {
+	return m.MockSecret, nil
 }
 
 // ServiceAccount returns a mock ServiceAccount object.

--- a/cli/pkg/k8s/resource_test.go
+++ b/cli/pkg/k8s/resource_test.go
@@ -111,7 +111,7 @@ metadata:
 		t.Run(tc.testName, func(t *testing.T) {
 			ctx := context.TODO()
 			fakeCS := fake.NewSimpleClientset(tc.objs...)
-			client := client{fakeCS, ""}
+			client := client{fakeCS}
 
 			resources, err := client.Resources(ctx)
 			if !errors.Is(err, tc.expErr) {


### PR DESCRIPTION
This PR changes the CLI to work by using the new auth/autoregistration flow. This means that when agent registration needs to happen, the CLI will not bring you to the Bcloud UI to create the agent but will instead render a manifest that will take care of registration. 

Additionally, the `check` command has been tweaked to check for the presence of the resources that are not required.