### PR TITLE
Fix crash when reading from nil response

### DIFF
--- a/agent/pkg/bcloudapi/client.go
+++ b/agent/pkg/bcloudapi/client.go
@@ -114,7 +114,7 @@ func (c *client) RegisterAgent(ctx context.Context, agentName string) (*AgentInf
 	defer rsp.Body.Close()
 
 	if rsp.StatusCode != http.StatusOK {
-		if apiErr := extractErrorFromResponse(rsp.Request.Response); apiErr != nil {
+		if apiErr := extractErrorFromResponse(rsp); apiErr != nil {
 			return nil, apiErr
 		}
 


### PR DESCRIPTION
User reported a crash on a nil `rsp.Request.Response`, when attempting
to extract an error.

Instead, read from `rsp` directly.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>